### PR TITLE
fix: correct Flex Query API hostname and endpoint paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1073,6 +1073,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2176,6 +2177,7 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -3391,6 +3393,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4793,6 +4796,7 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -7546,6 +7550,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8605,6 +8610,7 @@
       "integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^11.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -9451,6 +9457,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9539,6 +9546,7 @@
       "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -9585,6 +9593,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9740,6 +9749,7 @@
       "integrity": "sha512-oLnWs9Hak/LOlKjeSpOwD6JMks8BeICEdYMJBf6P4Lac/pO9tKiv/XhXnAM7nNfSkZahjlCZu9sS50zL8fSnsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -9881,6 +9891,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9894,6 +9905,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -10172,6 +10184,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/flex-query-client.ts
+++ b/src/flex-query-client.ts
@@ -26,7 +26,8 @@ export interface FlexStatementResponse {
 export class FlexQueryClient {
   private client: AxiosInstance;
   private token: string;
-  private baseUrl = "https://gdcdyn.interactivebrokers.com/Universal/servlet";
+  // Fixed: gdcdyn → ndcdyn, /Universal/servlet → /AccountManagement/FlexWebService
+  private baseUrl = "https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService";
 
   constructor(config: FlexQueryClientConfig) {
     this.token = config.token;
@@ -44,7 +45,7 @@ export class FlexQueryClient {
     try {
       Logger.log(`[FLEX-QUERY] Sending request for query ID: ${queryId}`);
       
-      const url = `${this.baseUrl}/FlexStatementService.SendRequest`;
+      const url = `${this.baseUrl}/SendRequest`;
       const params = {
         t: this.token,
         q: queryId,
@@ -95,7 +96,7 @@ export class FlexQueryClient {
     try {
       Logger.log(`[FLEX-QUERY] Getting statement for reference code: ${referenceCode}`);
       
-      const url = `${this.baseUrl}/FlexStatementService.GetStatement`;
+      const url = `${this.baseUrl}/GetStatement`;
       const params = {
         t: this.token,
         q: referenceCode,


### PR DESCRIPTION
## Problem
The Flex Query client was using incorrect hostname and API paths, causing DNS resolution errors:
- Wrong hostname: `gdcdyn.interactivebrokers.com` (does not exist)
- Wrong base path: `/Universal/servlet`
- Wrong endpoints: `/FlexStatementService.SendRequest`, `/FlexStatementService.GetStatement`

Error: `EAI_AGAIN gdcdyn.interactivebrokers.com`

## Solution
Updated to match IBKR Flex Web Service v3 API documentation:
- Fixed hostname: `ndcdyn.interactivebrokers.com`
- Fixed base path: `/AccountManagement/FlexWebService`
- Fixed endpoints: `/SendRequest`, `/GetStatement`

## Correct API Format
```
https://ndcdyn.interactivebrokers.com/AccountManagement/FlexWebService/SendRequest?t={Token}&q={QueryID}&v=3
```

## Reference
- IBKR API Docs: https://www.interactivebrokers.com/en/software/am/am/reports/flex_web_service_version_3.htm
- Tested with valid Flex Token and Query ID