### PR TITLE
feat: add exchange routing for orders/market data and TIF support

### DIFF
--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -20,6 +20,8 @@ export interface OrderRequest {
   price?: number;
   stopPrice?: number;
   suppressConfirmations?: boolean;
+  exchange?: string;
+  tif?: string;
 }
 
 const isError = (error: unknown): error is Error => {
@@ -324,13 +326,15 @@ export class IBClient {
 
   async getMarketData(symbol: string, exchange?: string): Promise<any> {
     try {
-      // First, get the contract ID for the symbol
-      const searchResponse = await this.client.get(
-        `/iserver/secdef/search?symbol=${symbol}`
-      );
+      // First, get the contract ID for the symbol, optionally filtered by exchange
+      let searchUrl = `/iserver/secdef/search?symbol=${encodeURIComponent(symbol)}`;
+      if (exchange) {
+        searchUrl += `&name=${encodeURIComponent(exchange)}`;
+      }
+      const searchResponse = await this.client.get(searchUrl);
       
       if (!searchResponse.data || searchResponse.data.length === 0) {
-        throw new Error(`Symbol ${symbol} not found`);
+        throw new Error(`Symbol ${symbol}${exchange ? ' on ' + exchange : ''} not found`);
       }
 
       const contract = searchResponse.data[0];
@@ -390,26 +394,33 @@ export class IBClient {
 
   async placeOrder(orderRequest: OrderRequest): Promise<any> {
     try {
-      // First, get the contract ID for the symbol
-      const searchResponse = await this.client.get(
-        `/iserver/secdef/search?symbol=${orderRequest.symbol}`
-      );
+      // First, get the contract ID for the symbol, optionally filtered by exchange
+      let searchUrl = `/iserver/secdef/search?symbol=${encodeURIComponent(orderRequest.symbol)}`;
+      if (orderRequest.exchange) {
+        searchUrl += `&name=${encodeURIComponent(orderRequest.exchange)}`;
+      }
+      const searchResponse = await this.client.get(searchUrl);
       
       if (!searchResponse.data || searchResponse.data.length === 0) {
-        throw new Error(`Symbol ${orderRequest.symbol} not found`);
+        throw new Error(`Symbol ${orderRequest.symbol}${orderRequest.exchange ? ' on ' + orderRequest.exchange : ''} not found`);
       }
 
       const contract = searchResponse.data[0];
       const conid = contract.conid;
 
       // Prepare order object
-      const order = {
+      const order: any = {
         conid: Number(conid), // Ensure conid is number
         orderType: orderRequest.orderType,
         side: orderRequest.action,
         quantity: Number(orderRequest.quantity), // Ensure quantity is number
-        tif: "DAY", // Time in force
+        tif: orderRequest.tif || "DAY", // Time in force - default to DAY to avoid orphaned orders
       };
+
+      // Include exchange if specified
+      if (orderRequest.exchange) {
+        order.exchange = orderRequest.exchange;
+      }
 
       // Add price for limit orders
       if (orderRequest.orderType === "LMT" && orderRequest.price !== undefined) {

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -34,7 +34,9 @@ export const PlaceOrderZodShape = {
   quantity: IntegerOrStringIntegerZod,
   price: z.number().optional(),
   stopPrice: z.number().optional(),
-  suppressConfirmations: z.boolean().optional()
+  suppressConfirmations: z.boolean().optional(),
+  exchange: z.string().optional(),
+  tif: z.enum(["DAY", "GTC", "IOC", "OPG"]).optional()
 };
 
 export const GetOrderStatusZodShape = {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -420,6 +420,8 @@ export class ToolHandlers {
         price: input.price,
         stopPrice: input.stopPrice,
         suppressConfirmations: input.suppressConfirmations,
+        exchange: input.exchange,
+        tif: input.tif,
       });
       return {
         content: [


### PR DESCRIPTION
## Summary

- Exchange-aware market data and order placement
- TIF (time-in-force) parameter on orders

## Changes

### `src/ib-client.ts`
- `OrderRequest` interface: added `exchange` and `tif` optional fields
- `getMarketData()`: the `exchange` parameter now routes through `secdef/search?name=<exchange>` instead of being silently ignored. Without exchange, IB's contract search returns the first match (e.g., CBA resolves to ClearBridge American Energy (US) instead of Commonwealth Bank of Australia (ASX))
- `placeOrder()`: same exchange routing, `exchange` included in order payload, `tif` defaults to `DAY` with user override via `orderRequest.tif`

### `src/tool-definitions.ts`
- `PlaceOrderZodShape`: added `exchange: z.string().optional()` and `tif: z.enum(["DAY", "GTC", "IOC", "OPG"]).optional()`

### `src/tool-handlers.ts`
- `placeOrder()` handler: passes `exchange` and `tif` through to the client

## Before/After

**Market data without exchange:**
```json
{ "conid": "130130381", "companyHeader": "CLEARBRIDGE AMERICAN ENERGY" }
```

**Market data with `exchange=ASX`:**
```json
{ "conid": "4036818", "companyHeader": "COMMONWEALTH BANK OF AUSTRAL (ASX)" }
```