### PR TITLE
fix: bridge browser OAuth to REST API session

### DIFF
--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -210,6 +210,40 @@ export class IBClient {
     this.stopTickle();
   }
 
+  /**
+   * Re-authenticate the REST API session after browser OAuth completes.
+   * This must be called after the browser login creates the server-side session.
+   */
+  async reauthenticate(): Promise<void> {
+    try {
+      const authClient = axios.create({
+        baseURL: this.baseUrl,
+        timeout: 30000,
+        httpsAgent: new https.Agent({
+          rejectUnauthorized: false,
+        }),
+      });
+      
+      Logger.log("[REAUTH] Re-authenticating REST session...");
+      await authClient.post("/iserver/reauthenticate");
+      
+      // Verify the reauthentication worked
+      const statusResponse = await authClient.get("/iserver/auth/status");
+      if (statusResponse.data.authenticated) {
+        Logger.log("[REAUTH] Re-authentication successful");
+        this.isAuthenticated = true;
+        this.authAttempts = 0;
+        this.startTickle();
+      } else {
+        Logger.warn("[REAUTH] Re-authentication request sent but auth status is still false, will retry via interceptor");
+        this.isAuthenticated = false;
+      }
+    } catch (error) {
+      Logger.warn("[REAUTH] Re-authentication failed, will fall back to interceptor-based auth:", error);
+      this.isAuthenticated = false;
+    }
+  }
+
   private async authenticate(): Promise<void> {
     Logger.log(`[AUTH] Starting authentication process... (attempt ${this.authAttempts + 1}/${this.maxAuthAttempts})`);
     this.authAttempts++;

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -107,12 +107,22 @@ export class ToolHandlers {
         throw new Error(`Authentication failed: ${result.message}`);
       }
     } else {
-      // In non-headless mode, throw an error asking user to authenticate manually
-      const port = this.context.gatewayManager 
-        ? this.context.gatewayManager.getCurrentPort() 
-        : this.context.config.IB_GATEWAY_PORT;
-      const authUrl = `https://${this.context.config.IB_GATEWAY_HOST}:${port}`;
-      throw new Error(`Authentication required. Please use the 'authenticate' tool to complete the authentication process at ${authUrl}.`);
+      // In non-headless mode, check if the gateway is already authenticated
+      // (the user may have completed browser auth via the authenticate tool)
+      const authStatus = await this.context.ibClient.checkAuthenticationStatus();
+      if (!authStatus) {
+        const port = this.context.gatewayManager 
+          ? this.context.gatewayManager.getCurrentPort() 
+          : this.context.config.IB_GATEWAY_PORT;
+        const authUrl = `https://${this.context.config.IB_GATEWAY_HOST}:${port}`;
+        throw new Error(`Authentication required. Please use the 'authenticate' tool to complete the authentication process at ${authUrl}.`);
+      }
+      // Auth status is true, reauthenticate the REST session if needed
+      try {
+        await this.context.ibClient.reauthenticate();
+      } catch (e) {
+        Logger.warn("[ENSURE-AUTH] Reauthenticate after status check failed, but status is true:", e);
+      }
     }
   }
 
@@ -143,6 +153,46 @@ export class ToolHandlers {
     const authUrl = `https://${this.context.config.IB_GATEWAY_HOST}:${port}`;
     const mode = this.context.config.IB_HEADLESS_MODE ? "headless mode" : "browser mode";
     return `Authentication required. Please use the 'authenticate' tool to complete the authentication process (configured for ${mode}) at ${authUrl}.`;
+  }
+
+  /**
+   * After browser opens for OAuth, poll the gateway until authenticated,
+   * then trigger reauthenticate to establish the REST API session.
+   * This bridges the gap between browser-based OAuth and the REST API auth state.
+   */
+  private startBrowserAuthPolling(authUrl: string, port: number): void {
+    const maxAttempts = 60; // 2 minutes total
+    const initialDelay = 2000; // 2 second initial delay
+    let attempts = 0;
+
+    const poll = async () => {
+      attempts++;
+      Logger.log(`[BROWSER-AUTH-POLL] Attempt ${attempts}/${maxAttempts}`);
+
+      try {
+        const isAuth = await this.context.ibClient.checkAuthenticationStatus();
+        
+        if (isAuth) {
+          Logger.log("[BROWSER-AUTH-POLL] Authentication detected, reauthenticating REST session");
+          // Trigger reauthenticate to establish REST API session
+          await this.context.ibClient.reauthenticate();
+          Logger.log("[BROWSER-AUTH-POLL] Reauthentication successful, REST session established");
+          return; // Success, stop polling
+        }
+      } catch (error) {
+        Logger.warn("[BROWSER-AUTH-POLL] Poll attempt failed:", error);
+      }
+
+      if (attempts < maxAttempts) {
+        const delay = Math.min(initialDelay + (attempts * 500), 10000);
+        setTimeout(poll, delay);
+      } else {
+        Logger.warn("[BROWSER-AUTH-POLL] Timed out waiting for browser authentication");
+      }
+    };
+
+    // Start polling after initial delay
+    setTimeout(poll, initialDelay);
   }
 
   private formatError(error: unknown): string {
@@ -241,6 +291,11 @@ export class ToolHandlers {
       try {
         await open(authUrl);
         
+        // Start polling for authentication to complete
+        // The browser auth creates a server-side session that the REST API can use
+        // We poll until authenticated, then trigger reauthenticate for the REST session
+        this.startBrowserAuthPolling(authUrl, port);
+        
         return {
           content: [
             {
@@ -257,7 +312,8 @@ export class ToolHandlers {
                   "5. Once authenticated, you can use other trading tools"
                 ],
                 browserOpened: true,
-                note: "IB Gateway is running locally - your credentials stay secure on your machine"
+                polling: true,
+                note: "IB Gateway is running locally - your credentials stay secure on your machine. Polling for authentication completion..."
               }, null, 2),
             },
           ],

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -353,6 +353,51 @@ describe('IBClient', () => {
     });
   });
 
+  describe('reauthenticate', () => {
+    it('should reauthenticate and start tickle on success', async () => {
+      const mockAuthClient = {
+        post: vi.fn().mockResolvedValue({ data: {} }),
+        get: vi.fn().mockResolvedValue({
+          data: { authenticated: true },
+        }),
+      };
+      
+      vi.mocked(axios.create).mockReturnValueOnce(mockAuthClient as any);
+      
+      await client.reauthenticate();
+      
+      expect(mockAuthClient.post).toHaveBeenCalledWith('/iserver/reauthenticate');
+      expect(mockAuthClient.get).toHaveBeenCalledWith('/iserver/auth/status');
+    });
+
+    it('should handle reauth when status returns false', async () => {
+      const mockAuthClient = {
+        post: vi.fn().mockResolvedValue({ data: {} }),
+        get: vi.fn().mockResolvedValue({
+          data: { authenticated: false },
+        }),
+      };
+      
+      vi.mocked(axios.create).mockReturnValueOnce(mockAuthClient as any);
+      
+      // Should not throw — handled internally
+      await expect(client.reauthenticate()).resolves.not.toThrow();
+      expect(mockAuthClient.post).toHaveBeenCalledWith('/iserver/reauthenticate');
+    });
+
+    it('should handle network errors gracefully', async () => {
+      const mockAuthClient = {
+        post: vi.fn().mockRejectedValue(new Error('Connection refused')),
+        get: vi.fn(),
+      };
+      
+      vi.mocked(axios.create).mockReturnValueOnce(mockAuthClient as any);
+      
+      // Should not throw — errors are caught internally
+      await expect(client.reauthenticate()).resolves.not.toThrow();
+    });
+  });
+
   describe('Cleanup', () => {
     it('should stop tickle on destroy', () => {
       // Start with authenticated state to trigger tickle

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ToolHandlers, ToolHandlerContext } from '../src/tool-handlers.js';
 import { IBClient } from '../src/ib-client.js';
 import { IBGatewayManager } from '../src/gateway-manager.js';
+import open from 'open';
 
 // Mock dependencies
 vi.mock('../src/ib-client.js');
@@ -22,6 +23,7 @@ describe('ToolHandlers', () => {
     // Create mock IBClient
     mockIBClient = {
       checkAuthenticationStatus: vi.fn().mockResolvedValue(true),
+      reauthenticate: vi.fn().mockResolvedValue(undefined),
       getAccountInfo: vi.fn().mockResolvedValue({ accounts: [] }),
       getPositions: vi.fn().mockResolvedValue([]),
       getMarketData: vi.fn().mockResolvedValue({ price: 150 }),
@@ -31,6 +33,10 @@ describe('ToolHandlers', () => {
       confirmOrder: vi.fn().mockResolvedValue({ confirmed: true }),
       destroy: vi.fn(),
       updatePort: vi.fn(),
+      getAlerts: vi.fn().mockResolvedValue([]),
+      createAlert: vi.fn().mockResolvedValue({ request_id: '1' }),
+      activateAlert: vi.fn().mockResolvedValue({ success: true }),
+      deleteAlert: vi.fn().mockResolvedValue({ success: true }),
     } as any;
 
     // Create mock GatewayManager
@@ -233,6 +239,74 @@ describe('ToolHandlers', () => {
     });
   });
 
+  describe('authenticate', () => {
+    it('should open browser and return polling response in browser mode', async () => {
+      context.config.IB_HEADLESS_MODE = false;
+      vi.mocked(open).mockResolvedValueOnce(undefined as any);
+
+      const result = await handlers.authenticate({ confirm: true });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.mode).toBe('browser');
+      expect(response.browserOpened).toBe(true);
+      expect(response.polling).toBe(true);
+      expect(response.authUrl).toContain('localhost:5000');
+      expect(vi.mocked(open)).toHaveBeenCalledWith(response.authUrl);
+    });
+
+    it('should return manual instructions when browser fails to open', async () => {
+      context.config.IB_HEADLESS_MODE = false;
+      vi.mocked(open).mockRejectedValueOnce(new Error('No browser available'));
+
+      const result = await handlers.authenticate({ confirm: true });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.mode).toBe('manual');
+      expect(response.browserOpened).toBe(false);
+      expect(response.instructions).toBeDefined();
+      expect(response.instructions.length).toBeGreaterThan(0);
+    });
+
+    it('should return full response with instructions in browser mode', async () => {
+      context.config.IB_HEADLESS_MODE = false;
+      vi.mocked(open).mockResolvedValueOnce(undefined as any);
+
+      const result = await handlers.authenticate({ confirm: true });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.mode).toBe('browser');
+      expect(response.browserOpened).toBe(true);
+      expect(response.polling).toBe(true);
+      expect(response.message).toContain('authentication interface opened');
+      expect(response.note).toContain('Polling for authentication completion');
+      expect(response.instructions).toHaveLength(5);
+      expect(response.instructions[0]).toContain('opened in your default browser');
+    });
+
+    it('should return missing credentials error in headless mode', async () => {
+      context.config.IB_HEADLESS_MODE = true;
+      context.config.IB_USERNAME = '';
+      context.config.IB_PASSWORD_AUTH = '';
+
+      const result = await handlers.authenticate({ confirm: true });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.success).toBe(false);
+      expect(response.error).toContain('IB_USERNAME');
+    });
+
+    it('should handle non-Error thrown by open', async () => {
+      context.config.IB_HEADLESS_MODE = false;
+      vi.mocked(open).mockRejectedValueOnce('spawn ENOENT');
+
+      const result = await handlers.authenticate({ confirm: true });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.mode).toBe('manual');
+      expect(response.browserOpened).toBe(false);
+    });
+  });
+
   describe('Headless Mode Authentication', () => {
     it('should trigger auth in headless mode', async () => {
       context.config.IB_HEADLESS_MODE = true;
@@ -248,6 +322,115 @@ describe('ToolHandlers', () => {
       const result = await handlers.getAccountInfo({ confirm: true });
 
       expect(result.content).toBeDefined();
+    });
+  });
+
+  describe('ensureAuth — browser mode', () => {
+    beforeEach(() => {
+      context.config.IB_HEADLESS_MODE = false;
+    });
+
+    it('should return early when already authenticated', async () => {
+      mockIBClient.checkAuthenticationStatus = vi.fn().mockResolvedValue(true);
+      mockIBClient.reauthenticate = vi.fn();
+
+      await (handlers as any).ensureAuth();
+
+      expect(mockIBClient.reauthenticate).not.toHaveBeenCalled();
+    });
+
+    it('should throw when not authenticated on both checks', async () => {
+      mockIBClient.checkAuthenticationStatus = vi.fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(false);
+      mockIBClient.reauthenticate = vi.fn();
+
+      await expect((handlers as any).ensureAuth())
+        .rejects.toThrow('Authentication required');
+      expect(mockIBClient.reauthenticate).not.toHaveBeenCalled();
+    });
+
+    it('should call reauthenticate when auth status flips to true', async () => {
+      mockIBClient.checkAuthenticationStatus = vi.fn()
+        .mockResolvedValueOnce(false)  // Continue past early return
+        .mockResolvedValueOnce(true);  // Browser path: now authenticated
+      mockIBClient.reauthenticate = vi.fn().mockResolvedValue(undefined);
+
+      await (handlers as any).ensureAuth();
+
+      expect(mockIBClient.reauthenticate).toHaveBeenCalled();
+    });
+
+    it('should proceed even if reauthenticate fails', async () => {
+      mockIBClient.checkAuthenticationStatus = vi.fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+      mockIBClient.reauthenticate = vi.fn().mockRejectedValue(new Error('Reauth failed'));
+
+      // Should not throw — error is caught and logged
+      await expect((handlers as any).ensureAuth()).resolves.not.toThrow();
+      expect(mockIBClient.reauthenticate).toHaveBeenCalled();
+    });
+  });
+
+  describe('startBrowserAuthPolling', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should poll and call reauthenticate when auth detected', async () => {
+      mockIBClient.checkAuthenticationStatus = vi.fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+      mockIBClient.reauthenticate = vi.fn().mockResolvedValue(undefined);
+
+      (handlers as any).startBrowserAuthPolling('https://localhost:5000', 5000);
+      await vi.runAllTimersAsync();
+
+      expect(mockIBClient.checkAuthenticationStatus).toHaveBeenCalledTimes(2);
+      expect(mockIBClient.reauthenticate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call reauthenticate when auth never detected', async () => {
+      mockIBClient.checkAuthenticationStatus = vi.fn().mockResolvedValue(false);
+      mockIBClient.reauthenticate = vi.fn();
+
+      (handlers as any).startBrowserAuthPolling('https://localhost:5000', 5000);
+      await vi.runAllTimersAsync();
+
+      expect(mockIBClient.checkAuthenticationStatus).toHaveBeenCalledTimes(60);
+      expect(mockIBClient.reauthenticate).not.toHaveBeenCalled();
+    });
+
+    it('should handle checkAuthenticationStatus throwing without stopping', async () => {
+      mockIBClient.checkAuthenticationStatus = vi.fn()
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce(true);
+      mockIBClient.reauthenticate = vi.fn().mockResolvedValue(undefined);
+
+      (handlers as any).startBrowserAuthPolling('https://localhost:5000', 5000);
+      await vi.runAllTimersAsync();
+
+      expect(mockIBClient.checkAuthenticationStatus).toHaveBeenCalledTimes(2);
+      expect(mockIBClient.reauthenticate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getAlerts', () => {
+    it('should return alerts for account', async () => {
+      const mockAlerts = [{ alertId: '1', alertName: 'Price Alert' }];
+      mockIBClient.getAlerts = vi.fn().mockResolvedValue(mockAlerts);
+
+      const result = await handlers.getAlerts({ accountId: 'U12345' });
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].type).toBe('text');
+      expect(mockGatewayManager.ensureGatewayReady).toHaveBeenCalled();
+      expect(mockIBClient.getAlerts).toHaveBeenCalledWith('U12345');
     });
   });
 


### PR DESCRIPTION
## Summary

Bridges the gap between browser-based OAuth and the REST API session. After the `authenticate` tool opens the browser for login, a background polling loop detects when authentication completes and triggers the REST API session automatically — no more manual re-auth required.

## Problem

Before this fix:
1. User calls `authenticate` → browser opens → user logs in → "Client login succeeds"
2. User calls any trading tool → "Authentication required"
3. Session works inconsistently — account info sometimes works, orders/alerts don't

Root cause: browser OAuth creates a server-side session, but the MCP server never detected or bridged to it. The `ensureAuth()` method always threw in non-headless mode, and no reauthentication was triggered.

## Changes

### `src/ib-client.ts`
- Added public `reauthenticate()` method that triggers `POST /iserver/reauthenticate` and verifies with `GET /iserver/auth/status`, establishing the REST API session with tickle heartbeat

### `src/tool-handlers.ts`
- Added `startBrowserAuthPolling()` — after browser opens, polls `checkAuthenticationStatus()` every 2-10s for up to 2 minutes. When authenticated, calls `reauthenticate()` to bridge the session
- Fixed `ensureAuth()` — checks auth status before throwing in browser mode, and calls `reauthenticate()` if gateway shows authenticated
- Updated browser-mode authenticate handler to start background polling and show `polling: true` in response

## Testing

Verified live: after browser login, both `get_account_info` and `get_alerts` succeeded immediately without any manual re-authentication step.