### PR TITLE
ci: fix npm trusted publishing release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,13 @@ jobs:
         run: npm test --if-present
 
       - name: Semantic Release
+        id: semantic
         uses: cycjimmy/semantic-release-action@v4
         with:
           semantic_version: 24
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to npm (trusted publishing via OIDC)
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: npm publish --provenance --access public

--- a/.releaserc
+++ b/.releaserc
@@ -21,7 +21,7 @@
         ]
       }
     ],
-    "@semantic-release/npm",
+    ["@semantic-release/npm", { "npmPublish": false }],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- Disable publish in `@semantic-release/npm` (avoids the `npm whoami` auth check that fails without `NPM_TOKEN`)
- Add an explicit `npm publish --provenance --access public` step after Semantic Release, gated on `new_release_published`
- npm 11+ picks up OIDC automatically from the existing `id-token: write` permission, so no token is needed

## Why
The previous OIDC switch (#27) failed in CI with `EINVALIDNPMTOKEN` because `@semantic-release/npm` doesn't natively support trusted publishing — it tries to verify auth via a token before reaching the publish step. This keeps semantic-release for versioning + GitHub release while letting the npm CLI handle the publish via OIDC.

## Test plan
- [ ] Confirm trusted publishing is configured for \`interactive-brokers-mcp\` on npmjs.com (Settings → Publishing access → GitHub Actions, repo \`code-rabi/interactive-brokers-mcp\`, workflow \`release.yml\`, environment blank)
- [ ] Merge and watch the next \`master\` release run; verify the GitHub release is created and the package publishes with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)