### PR TITLE
ci: add knip dead-code check

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -1,0 +1,27 @@
+name: Knip
+
+on:
+  push:
+    branches: [main, master, develop]
+  pull_request:
+    branches: [main, master, develop]
+
+jobs:
+  knip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run knip
+        run: npx -y knip@5

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "ignore": ["ib-gateway/**"],
+  "ignoreDependencies": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/github",
+    "@semantic-release/npm",
+    "@semantic-release/release-notes-generator",
+    "conventional-changelog-conventionalcommits",
+    "semantic-release"
+  ]
+}

--- a/src/flex-query-client.ts
+++ b/src/flex-query-client.ts
@@ -2,18 +2,18 @@ import axios, { AxiosInstance } from "axios";
 import { Logger } from "./logger.js";
 import { parseStringPromise } from "xml2js";
 
-export interface FlexQueryClientConfig {
+interface FlexQueryClientConfig {
   token: string;
 }
 
-export interface FlexQueryResponse {
+interface FlexQueryResponse {
   referenceCode?: string;
   url?: string;
   error?: string;
   errorCode?: string;
 }
 
-export interface FlexStatementResponse {
+interface FlexStatementResponse {
   data?: string; // XML data
   error?: string;
   errorCode?: string;

--- a/src/flex-query-storage.ts
+++ b/src/flex-query-storage.ts
@@ -12,7 +12,7 @@ export interface SavedFlexQuery {
   lastUsed?: string;
 }
 
-export interface FlexQueriesStore {
+interface FlexQueriesStore {
   queries: SavedFlexQuery[];
 }
 

--- a/src/headless-auth.ts
+++ b/src/headless-auth.ts
@@ -12,7 +12,7 @@ export interface HeadlessAuthConfig {
   paperTrading?: boolean;
 }
 
-export interface HeadlessAuthResult {
+interface HeadlessAuthResult {
   success: boolean;
   message: string;
   waitingFor2FA?: boolean;

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -6,12 +6,12 @@ interface ExtendedAxiosRequestConfig extends AxiosRequestConfig {
   metadata?: { requestId: string };
 }
 
-export interface IBClientConfig {
+interface IBClientConfig {
   host: string;
   port: number;
 }
 
-export interface OrderRequest {
+interface OrderRequest {
   accountId: string;
   symbol: string;
   action: "BUY" | "SELL";

--- a/src/server.ts
+++ b/src/server.ts
@@ -86,11 +86,6 @@ export function createIBMCPServer({ config: userConfig }: { config: z.infer<type
   return server;
 }
 
-export { gatewayManager };
-
-
-
-
 
 
 

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -31,7 +31,7 @@ export interface ToolHandlerContext {
   flexQueryStorage?: FlexQueryStorage;
 }
 
-export type ToolHandlerResult = {
+type ToolHandlerResult = {
   content: Array<{
     type: "text";
     text: string;


### PR DESCRIPTION
## Summary
- Adds a `Knip` GitHub workflow that runs on push/PR to `main`/`master`/`develop` (mirrors the existing tests workflow) and pins to `knip@5` via `npx`.
- Adds `knip.json` ignoring the vendored `ib-gateway/**` tree and the six `@semantic-release/*` + `conventional-changelog-conventionalcommits` devDeps (used by the release workflow, not imported in source).
- Removes one dead re-export (`gatewayManager` from `src/server.ts`) and drops the `export` keyword from 8 internal-only interfaces/types that had no external consumers (`FlexQueryClientConfig`, `FlexQueryResponse`, `FlexStatementResponse`, `FlexQueriesStore`, `HeadlessAuthResult`, `IBClientConfig`, `OrderRequest`, `ToolHandlerResult`). Safe because the package is published as a CLI (`bin`), not a library.

## Test plan
- [x] `npx knip@5` exits clean locally
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 123 tests pass, 1 skipped
- [ ] Knip workflow passes on this PR in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)