### PR TITLE
fix: add repository URL to package.json for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,14 @@
   ],
   "author": "Nitay Rabinovich",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/code-rabi/interactive-brokers-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/code-rabi/interactive-brokers-mcp/issues"
+  },
+  "homepage": "https://github.com/code-rabi/interactive-brokers-mcp#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.2",
     "axios": "^1.6.0",


### PR DESCRIPTION
## Summary
- npm publish was failing with E422 because sigstore provenance verification expects `repository.url` in `package.json` to match the GitHub repo URL, and the field was missing entirely.
- Adds `repository`, `bugs`, and `homepage` fields pointing to `code-rabi/interactive-brokers-mcp`.

## Test plan
- [ ] Trigger a release and confirm `npm publish` with `--provenance` succeeds (no E422 from sigstore verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)