### PR TITLE
docs: add contributors thanks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,11 @@ For a complete guide on creating and customizing Flex Queries, see the [IB Flex 
 ## License
 
 MIT License - see LICENSE file for details.
+
+## Thanks to our contributors
+
+A big thank you to everyone who has contributed to making this project better.
+
+<a href="https://github.com/code-rabi/interactive-brokers-mcp/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=code-rabi/interactive-brokers-mcp" alt="Contributors" />
+</a>


### PR DESCRIPTION
## Summary
- Adds a "Thanks to our contributors" section to the bottom of the README, using the [contrib.rocks](https://contrib.rocks) widget so the avatar grid stays in sync with GitHub's contributor graph automatically.

## Test plan
- [ ] Render the README on GitHub and confirm the contributor avatar image loads
- [ ] Confirm the link points to the contributors graph for this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)