### PR TITLE
fix(orders): preserve "Symbol not found" errors and narrow tif type (followup to #24)

### DIFF
--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -21,12 +21,24 @@ interface OrderRequest {
   stopPrice?: number;
   suppressConfirmations?: boolean;
   exchange?: string;
-  tif?: string;
+  tif?: "DAY" | "GTC" | "IOC" | "OPG";
 }
 
 const isError = (error: unknown): error is Error => {
   return error instanceof Error;
 };
+
+/**
+ * Thrown when a symbol (optionally scoped to an exchange) cannot be resolved
+ * via `secdef/search`. Distinct error class so callers receive the specific
+ * "Symbol ... not found" message instead of a swallowed generic one.
+ */
+export class SymbolNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SymbolNotFoundError";
+  }
+}
 
 export class IBClient {
   private client!: AxiosInstance;
@@ -366,9 +378,9 @@ export class IBClient {
         searchUrl += `&name=${encodeURIComponent(exchange)}`;
       }
       const searchResponse = await this.client.get(searchUrl);
-      
+
       if (!searchResponse.data || searchResponse.data.length === 0) {
-        throw new Error(`Symbol ${symbol}${exchange ? ' on ' + exchange : ''} not found`);
+        throw new SymbolNotFoundError(`Symbol ${symbol}${exchange ? ' on ' + exchange : ''} not found`);
       }
 
       const contract = searchResponse.data[0];
@@ -389,14 +401,19 @@ export class IBClient {
       };
     } catch (error) {
       Logger.error("Failed to get market data:", error);
-      
+
       // Check if this is likely an authentication error
       if (this.isAuthenticationError(error)) {
         const authError = new Error(`Authentication required to retrieve market data for ${symbol}. Please authenticate with Interactive Brokers first.`);
         (authError as any).isAuthError = true;
         throw authError;
       }
-      
+
+      // Preserve the specific "Symbol ... not found" message for callers
+      if (error instanceof SymbolNotFoundError) {
+        throw error;
+      }
+
       throw new Error(`Failed to retrieve market data for ${symbol}`);
     }
   }
@@ -434,9 +451,9 @@ export class IBClient {
         searchUrl += `&name=${encodeURIComponent(orderRequest.exchange)}`;
       }
       const searchResponse = await this.client.get(searchUrl);
-      
+
       if (!searchResponse.data || searchResponse.data.length === 0) {
-        throw new Error(`Symbol ${orderRequest.symbol}${orderRequest.exchange ? ' on ' + orderRequest.exchange : ''} not found`);
+        throw new SymbolNotFoundError(`Symbol ${orderRequest.symbol}${orderRequest.exchange ? ' on ' + orderRequest.exchange : ''} not found`);
       }
 
       const contract = searchResponse.data[0];
@@ -491,14 +508,19 @@ export class IBClient {
       return response.data;
     } catch (error) {
       Logger.error("Failed to place order:", error);
-      
+
       // Check if this is likely an authentication error
       if (this.isAuthenticationError(error)) {
         const authError = new Error("Authentication required to place orders. Please authenticate with Interactive Brokers first.");
         (authError as any).isAuthError = true;
         throw authError;
       }
-      
+
+      // Preserve the specific "Symbol ... not found" message for callers
+      if (error instanceof SymbolNotFoundError) {
+        throw error;
+      }
+
       throw new Error("Failed to place order");
     }
   }

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -1,6 +1,6 @@
 // test/ib-client.test.ts
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { IBClient } from '../src/ib-client.js';
+import { IBClient, SymbolNotFoundError } from '../src/ib-client.js';
 import axios from 'axios';
 
 // Mock axios
@@ -176,12 +176,66 @@ describe('IBClient', () => {
 
       it('should throw error if symbol not found', async () => {
         const mockClient = vi.mocked(axios.create).mock.results[0].value;
-        
+
         // Mock empty search response
         mockClient.get.mockResolvedValueOnce({ data: [] });
-        
+
+        // The specific "Symbol ... not found" message should reach the caller
+        // (not be swallowed by the generic "Failed to retrieve market data" catch)
         await expect(client.getMarketData('INVALID')).rejects.toThrow(
-          'Failed to retrieve market data'
+          'Symbol INVALID not found'
+        );
+      });
+
+      it('should propagate SymbolNotFoundError instance to callers', async () => {
+        const mockClient = vi.mocked(axios.create).mock.results[0].value;
+
+        mockClient.get.mockResolvedValueOnce({ data: [] });
+
+        await expect(client.getMarketData('INVALID')).rejects.toBeInstanceOf(SymbolNotFoundError);
+      });
+
+      it('should include exchange in secdef/search URL when provided', async () => {
+        const mockClient = vi.mocked(axios.create).mock.results[0].value;
+
+        mockClient.get.mockResolvedValueOnce({
+          data: [{ conid: 265598, symbol: 'AAPL' }],
+        });
+        mockClient.get.mockResolvedValueOnce({
+          data: [{ conid: 265598, price: 150.25 }],
+        });
+
+        await client.getMarketData('AAPL', 'NASDAQ');
+
+        expect(mockClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('/iserver/secdef/search?symbol=AAPL&name=NASDAQ')
+        );
+      });
+
+      it('should URL-encode the exchange parameter', async () => {
+        const mockClient = vi.mocked(axios.create).mock.results[0].value;
+
+        mockClient.get.mockResolvedValueOnce({
+          data: [{ conid: 265598, symbol: 'AAPL' }],
+        });
+        mockClient.get.mockResolvedValueOnce({
+          data: [{ conid: 265598, price: 150.25 }],
+        });
+
+        await client.getMarketData('AAPL', 'NYSE ARCA');
+
+        expect(mockClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('&name=NYSE%20ARCA')
+        );
+      });
+
+      it('should mention the exchange in the not-found error when provided', async () => {
+        const mockClient = vi.mocked(axios.create).mock.results[0].value;
+
+        mockClient.get.mockResolvedValueOnce({ data: [] });
+
+        await expect(client.getMarketData('INVALID', 'NASDAQ')).rejects.toThrow(
+          'Symbol INVALID on NASDAQ not found'
         );
       });
     });
@@ -258,6 +312,133 @@ describe('IBClient', () => {
             ]),
           })
         );
+      });
+
+      it('should default tif to DAY when not specified', async () => {
+        const mockClient = vi.mocked(axios.create).mock.results[0].value;
+
+        mockClient.get.mockResolvedValueOnce({
+          data: [{ conid: 265598, symbol: 'AAPL' }],
+        });
+        mockClient.post.mockResolvedValueOnce({
+          data: [{ id: 'order-123' }],
+        });
+
+        await client.placeOrder({
+          accountId: 'U12345',
+          symbol: 'AAPL',
+          action: 'BUY',
+          orderType: 'MKT',
+          quantity: 10,
+        });
+
+        expect(mockClient.post).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            orders: expect.arrayContaining([
+              expect.objectContaining({ tif: 'DAY' }),
+            ]),
+          })
+        );
+      });
+
+      it('should use the user-provided tif when given', async () => {
+        const mockClient = vi.mocked(axios.create).mock.results[0].value;
+
+        mockClient.get.mockResolvedValueOnce({
+          data: [{ conid: 265598, symbol: 'AAPL' }],
+        });
+        mockClient.post.mockResolvedValueOnce({
+          data: [{ id: 'order-123' }],
+        });
+
+        await client.placeOrder({
+          accountId: 'U12345',
+          symbol: 'AAPL',
+          action: 'BUY',
+          orderType: 'MKT',
+          quantity: 10,
+          tif: 'GTC',
+        });
+
+        expect(mockClient.post).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            orders: expect.arrayContaining([
+              expect.objectContaining({ tif: 'GTC' }),
+            ]),
+          })
+        );
+      });
+
+      it('should include exchange in secdef/search URL when provided', async () => {
+        const mockClient = vi.mocked(axios.create).mock.results[0].value;
+
+        mockClient.get.mockResolvedValueOnce({
+          data: [{ conid: 265598, symbol: 'AAPL' }],
+        });
+        mockClient.post.mockResolvedValueOnce({
+          data: [{ id: 'order-123' }],
+        });
+
+        await client.placeOrder({
+          accountId: 'U12345',
+          symbol: 'AAPL',
+          action: 'BUY',
+          orderType: 'MKT',
+          quantity: 10,
+          exchange: 'NASDAQ',
+        });
+
+        expect(mockClient.get).toHaveBeenCalledWith(
+          expect.stringContaining('/iserver/secdef/search?symbol=AAPL&name=NASDAQ')
+        );
+      });
+
+      it('should include exchange in the order payload when specified', async () => {
+        const mockClient = vi.mocked(axios.create).mock.results[0].value;
+
+        mockClient.get.mockResolvedValueOnce({
+          data: [{ conid: 265598, symbol: 'AAPL' }],
+        });
+        mockClient.post.mockResolvedValueOnce({
+          data: [{ id: 'order-123' }],
+        });
+
+        await client.placeOrder({
+          accountId: 'U12345',
+          symbol: 'AAPL',
+          action: 'BUY',
+          orderType: 'MKT',
+          quantity: 10,
+          exchange: 'NASDAQ',
+        });
+
+        expect(mockClient.post).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            orders: expect.arrayContaining([
+              expect.objectContaining({ exchange: 'NASDAQ' }),
+            ]),
+          })
+        );
+      });
+
+      it('should propagate SymbolNotFoundError when symbol cannot be resolved', async () => {
+        const mockClient = vi.mocked(axios.create).mock.results[0].value;
+
+        // Mock empty search response — no matching symbol
+        mockClient.get.mockResolvedValueOnce({ data: [] });
+
+        await expect(
+          client.placeOrder({
+            accountId: 'U12345',
+            symbol: 'INVALID',
+            action: 'BUY',
+            orderType: 'MKT',
+            quantity: 10,
+          })
+        ).rejects.toThrow('Symbol INVALID not found');
       });
 
       it('should include stopPrice for stop orders', async () => {

--- a/test/tool-definitions.test.ts
+++ b/test/tool-definitions.test.ts
@@ -164,7 +164,52 @@ describe('Tool Definitions - Zod Schemas', () => {
         quantity: 10,
         suppressConfirmations: true,
       };
-      
+
+      const result = PlaceOrderZodSchema.safeParse(validOrder);
+      expect(result.success).toBe(true);
+    });
+
+    it.each(['DAY', 'GTC', 'IOC', 'OPG'] as const)(
+      'should accept tif value %s',
+      (tif) => {
+        const validOrder = {
+          accountId: 'U12345',
+          symbol: 'AAPL',
+          action: 'BUY' as const,
+          orderType: 'MKT' as const,
+          quantity: 10,
+          tif,
+        };
+
+        const result = PlaceOrderZodSchema.safeParse(validOrder);
+        expect(result.success).toBe(true);
+      }
+    );
+
+    it('should reject an invalid tif value', () => {
+      const invalidOrder = {
+        accountId: 'U12345',
+        symbol: 'AAPL',
+        action: 'BUY' as const,
+        orderType: 'MKT' as const,
+        quantity: 10,
+        tif: 'BAD',
+      };
+
+      const result = PlaceOrderZodSchema.safeParse(invalidOrder);
+      expect(result.success).toBe(false);
+    });
+
+    it('should accept exchange when provided alongside required fields', () => {
+      const validOrder = {
+        accountId: 'U12345',
+        symbol: 'AAPL',
+        action: 'BUY' as const,
+        orderType: 'MKT' as const,
+        quantity: 10,
+        exchange: 'NASDAQ',
+      };
+
       const result = PlaceOrderZodSchema.safeParse(validOrder);
       expect(result.success).toBe(true);
     });

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -173,6 +173,30 @@ describe('ToolHandlers', () => {
       );
     });
 
+    it('should forward exchange and tif to ibClient.placeOrder when provided', async () => {
+      const mockResponse = { orderId: '123', status: 'Submitted' };
+      mockIBClient.placeOrder = vi.fn().mockResolvedValue(mockResponse);
+
+      const orderInput = {
+        accountId: 'U12345',
+        symbol: 'AAPL',
+        action: 'BUY' as const,
+        orderType: 'MKT' as const,
+        quantity: 10,
+        exchange: 'NASDAQ',
+        tif: 'GTC' as const,
+      };
+
+      await handlers.placeOrder(orderInput);
+
+      expect(mockIBClient.placeOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          exchange: 'NASDAQ',
+          tif: 'GTC',
+        })
+      );
+    });
+
     it('should handle order placement errors', async () => {
       mockIBClient.placeOrder = vi.fn().mockRejectedValue(new Error('Order failed'));
 


### PR DESCRIPTION
## Summary

Followup to #24 — addresses Copilot review comments that landed after the original PR was merged. Thanks again @shanehull for the original feature.

- Introduce a dedicated `SymbolNotFoundError` class so the specific `Symbol ... not found` message reaches callers of `getMarketData()` and `placeOrder()` instead of being swallowed by the generic `Failed to retrieve market data` / `Failed to place order` catches.
- Narrow `OrderRequest.tif` from `string` to the literal union `"DAY" | "GTC" | "IOC" | "OPG"` to match the Zod enum already enforced at the boundary.
- Add tests for: exchange routing (`&name=…` URL-encoded) on both `getMarketData` and `placeOrder`, exchange in the order payload, `tif` defaulting to `DAY`, user-provided `tif` pass-through, schema validation of valid/invalid `tif` values plus `exchange`, and handler-level pass-through of `exchange` and `tif` to `ibClient.placeOrder`.

The auth-error branch in each catch block is preserved and still takes precedence over the new `SymbolNotFoundError` rethrow.

## Test plan

- [x] `npm test` — 161 passed (1 pre-existing skip)
- [x] `npx knip@5` — no new findings (only pre-existing warnings about `tsx`/`tsc`/`vitest` unrelated to this change)
- [x] `npm run build` — clean compile
- [ ] Reviewer: confirm the updated `'should throw error if symbol not found'` assertion now matches the more-specific message reaching the caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)