### PR TITLE
fix: initialize Client Portal brokerage session via ssodh form flow

### DIFF
--- a/src/headless-auth.ts
+++ b/src/headless-auth.ts
@@ -135,13 +135,30 @@ export class HeadlessAuthenticator {
           const authSuccess = pageContent.includes('Client login succeeds');
 
           if (authSuccess) {
-            Logger.info('🎉 Authentication completed! Found "Client login succeeds" message.');
-            await this.cleanup();
-            
-            return {
-              success: true,
-              message: 'Headless authentication completed successfully. Client login succeeds message detected.'
-            };
+            Logger.info('🎉 Browser login reports "Client login succeeds"; initializing REST brokerage session...');
+
+            if (authConfig.ibClient) {
+              await authConfig.ibClient.reauthenticate();
+              const isAuthenticated = await authConfig.ibClient.checkAuthenticationStatus();
+              if (isAuthenticated) {
+                Logger.info('🎉 Authentication completed! IB Client confirmed REST brokerage authentication.');
+                await this.cleanup();
+
+                return {
+                  success: true,
+                  message: 'Headless authentication completed successfully. REST brokerage session confirmed.'
+                };
+              }
+
+              Logger.info('🔍 Browser login succeeded, but REST brokerage session is not authenticated yet; continuing to wait...');
+            } else {
+              await this.cleanup();
+
+              return {
+                success: true,
+                message: 'Headless browser login completed. No IB client was provided to verify REST brokerage authentication.'
+              };
+            }
           }
 
           // Check for potential 2FA or other intermediate states

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -116,6 +116,20 @@ export class IBClient {
     );
   }
 
+  private createRawClient(timeout = 30000): AxiosInstance {
+    return axios.create({
+      baseURL: this.baseUrl,
+      timeout,
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: false,
+      }),
+    });
+  }
+
+  private isStatusAuthenticated(status: any): boolean {
+    return status?.authenticated === true && status?.connected !== false;
+  }
+
   updatePort(newPort: number): void {
     if (this.config.port !== newPort) {
       Logger.log(`[CLIENT] Updating port from ${this.config.port} to ${newPort}`);
@@ -135,18 +149,12 @@ export class IBClient {
       Logger.log("[AUTH-CHECK] Checking authentication status...");
       
       // Create a new axios instance without interceptors to avoid triggering authentication
-      const authClient = axios.create({
-        baseURL: this.baseUrl,
-        timeout: 30000,
-        httpsAgent: new https.Agent({
-          rejectUnauthorized: false,
-        }),
-      });
+      const authClient = this.createRawClient();
       
       const response = await authClient.get("/iserver/auth/status");
       Logger.log("[AUTH-CHECK] Auth status response:", response.data);
       
-      const authenticated = response.data.authenticated === true;
+      const authenticated = this.isStatusAuthenticated(response.data);
       this.isAuthenticated = authenticated;
       
       if (authenticated) {
@@ -171,13 +179,7 @@ export class IBClient {
   private async tickle(): Promise<void> {
     try {
       // Create a new axios instance without interceptors to avoid triggering authentication
-      const tickleClient = axios.create({
-        baseURL: this.baseUrl,
-        timeout: 10000,
-        httpsAgent: new https.Agent({
-          rejectUnauthorized: false,
-        }),
-      });
+      const tickleClient = this.createRawClient(10000);
       
       await tickleClient.post("/tickle");
       Logger.log("[TICKLE] Session maintenance ping sent successfully");
@@ -225,33 +227,97 @@ export class IBClient {
   }
 
   /**
+   * Initialize/recover the Client Portal Gateway brokerage session.
+   *
+   * A Gateway web login can produce a valid SSO session while `/iserver/auth/status`
+   * remains `authenticated:false`. IBKR's brokerage-session init endpoint requires
+   * an x-www-form-urlencoded body derived from auth/status. An empty POST may return
+   * HTTP 200 but leave the session unauthenticated with:
+   * "Force compete capability must be used together with compete flag".
+   */
+  private async initializeBrokerageSession(): Promise<boolean> {
+    const authClient = this.createRawClient();
+
+    Logger.log("[BROKERAGE-INIT] Validating SSO session...");
+    await authClient.get("/sso/validate");
+
+    Logger.log("[BROKERAGE-INIT] Reading auth status for MAC/hardware info...");
+    let statusResponse = await authClient.get("/iserver/auth/status");
+    Logger.log("[BROKERAGE-INIT] Auth status response:", statusResponse.data);
+
+    if (this.isStatusAuthenticated(statusResponse.data)) {
+      this.isAuthenticated = true;
+      this.authAttempts = 0;
+      this.startTickle();
+      return true;
+    }
+
+    const rawMac = String(statusResponse.data?.MAC || "");
+    const rawHardware = String(statusResponse.data?.hardware_info || "");
+    const machineId = rawHardware.split("|")[0] || "";
+    const mac = rawMac.replaceAll(":", "-");
+
+    // This endpoint may 401 before the brokerage session is initialized, but it
+    // can also trigger Gateway-side state; treat failures as non-fatal.
+    try {
+      await authClient.get("/iserver/accounts");
+    } catch (error) {
+      Logger.debug("[BROKERAGE-INIT] /iserver/accounts not ready before ssodh/init; continuing", error);
+    }
+
+    if (!machineId || !mac) {
+      Logger.warn("[BROKERAGE-INIT] Missing machineId or MAC from /iserver/auth/status; cannot call ssodh/init form flow");
+      this.isAuthenticated = false;
+      this.stopTickle();
+      return false;
+    }
+
+    const ssodhBody = new URLSearchParams({
+      compete: "true",
+      locale: "en_US",
+      mac,
+      machineId,
+      username: "-",
+    }).toString();
+
+    Logger.log("[BROKERAGE-INIT] Initializing brokerage session via /iserver/auth/ssodh/init...");
+    await authClient.post("/iserver/auth/ssodh/init", ssodhBody, {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+
+    Logger.log("[BROKERAGE-INIT] Triggering /iserver/reauthenticate...");
+    await authClient.post("/iserver/reauthenticate");
+
+    // /tickle both keeps the session alive and returns nested iserver authStatus.
+    await authClient.post("/tickle");
+
+    statusResponse = await authClient.get("/iserver/auth/status");
+    Logger.log("[BROKERAGE-INIT] Final auth status response:", statusResponse.data);
+
+    const authenticated = this.isStatusAuthenticated(statusResponse.data);
+    this.isAuthenticated = authenticated;
+
+    if (authenticated) {
+      this.authAttempts = 0;
+      this.startTickle();
+    } else {
+      this.stopTickle();
+    }
+
+    return authenticated;
+  }
+
+  /**
    * Re-authenticate the REST API session after browser OAuth completes.
    * This must be called after the browser login creates the server-side session.
    */
   async reauthenticate(): Promise<void> {
     try {
-      const authClient = axios.create({
-        baseURL: this.baseUrl,
-        timeout: 30000,
-        httpsAgent: new https.Agent({
-          rejectUnauthorized: false,
-        }),
-      });
-      
-      Logger.log("[REAUTH] Re-authenticating REST session...");
-      await authClient.post("/iserver/reauthenticate");
-      
-      // Verify the reauthentication worked
-      const statusResponse = await authClient.get("/iserver/auth/status");
-      if (statusResponse.data.authenticated) {
+      const authenticated = await this.initializeBrokerageSession();
+      if (authenticated) {
         Logger.log("[REAUTH] Re-authentication successful");
-        this.isAuthenticated = true;
-        this.authAttempts = 0;
-        this.startTickle();
       } else {
         Logger.warn("[REAUTH] Re-authentication request sent but auth status is still false, will retry via interceptor");
-        this.isAuthenticated = false;
-        this.stopTickle();
       }
     } catch (error) {
       Logger.warn("[REAUTH] Re-authentication failed, will fall back to interceptor-based auth:", error);
@@ -265,37 +331,17 @@ export class IBClient {
     this.authAttempts++;
     
     try {
-      // Create a new axios instance without interceptors to avoid infinite recursion
-      const authClient = axios.create({
-        baseURL: this.baseUrl,
-        timeout: 30000,
-        httpsAgent: new https.Agent({
-          rejectUnauthorized: false,
-        }),
-      });
-      
-      // Check if already authenticated
-      Logger.log("[AUTH] Checking authentication status...");
-      const response = await authClient.get("/iserver/auth/status");
-      Logger.log("[AUTH] Auth status response:", response.data);
-      
-      if (response.data.authenticated) {
-        Logger.log("[AUTH] Already authenticated");
-        this.isAuthenticated = true;
-        this.authAttempts = 0; // Reset on success
-        this.startTickle(); // Start session maintenance
+      const authenticated = await this.initializeBrokerageSession();
+      if (authenticated) {
+        Logger.log("[AUTH] Brokerage session authenticated");
         return;
       }
 
-      // Re-authenticate if needed
-      Logger.log("[AUTH] Re-authenticating...");
-      await authClient.post("/iserver/reauthenticate");
-      Logger.log("[AUTH] Re-authentication successful");
-      this.isAuthenticated = true;
-      this.authAttempts = 0; // Reset on success
-      this.startTickle(); // Start session maintenance
+      throw new Error("Gateway is reachable but the IBKR brokerage session is not authenticated yet. Complete browser/2FA login and retry.");
     } catch (error) {
       Logger.error(`[AUTH] Authentication failed (attempt ${this.authAttempts}/${this.maxAuthAttempts}):`, isError(error) && error.message, isError(error) && error.stack);
+      this.isAuthenticated = false;
+      this.stopTickle();
       if (this.authAttempts >= this.maxAuthAttempts) {
         throw new Error(`Failed to authenticate with IB Gateway after ${this.maxAuthAttempts} attempts`);
       }

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -238,6 +238,7 @@ export class ToolHandlers {
             username: this.context.config.IB_USERNAME,
             password: this.context.config.IB_PASSWORD_AUTH,
             timeout: this.context.config.IB_AUTH_TIMEOUT,
+            ibClient: this.context.ibClient,
           };
 
           // Validate that we have credentials for headless mode

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -535,41 +535,85 @@ describe('IBClient', () => {
   });
 
   describe('reauthenticate', () => {
-    it('should reauthenticate and start tickle on success', async () => {
+    it('should initialize brokerage session using the official ssodh/init form body', async () => {
       const mockAuthClient = {
         post: vi.fn().mockResolvedValue({ data: {} }),
-        get: vi.fn().mockResolvedValue({
-          data: { authenticated: true },
-        }),
+        get: vi.fn()
+          .mockResolvedValueOnce({ data: { RESULT: true } })
+          .mockResolvedValueOnce({
+            data: {
+              authenticated: false,
+              connected: true,
+              MAC: '06:7F:1D:C4:36:2F',
+              hardware_info: '71a482fc|06:7F:1D:C4:36:2F',
+            },
+          })
+          .mockRejectedValueOnce(new Error('not ready'))
+          .mockResolvedValueOnce({
+            data: { authenticated: true, connected: true, established: true },
+          }),
       };
       
       vi.mocked(axios.create).mockReturnValueOnce(mockAuthClient as any);
       
       await client.reauthenticate();
       
-      expect(mockAuthClient.post).toHaveBeenCalledWith('/iserver/reauthenticate');
+      expect(mockAuthClient.get).toHaveBeenCalledWith('/sso/validate');
       expect(mockAuthClient.get).toHaveBeenCalledWith('/iserver/auth/status');
+      expect(mockAuthClient.get).toHaveBeenCalledWith('/iserver/accounts');
+      expect(mockAuthClient.post).toHaveBeenCalledWith(
+        '/iserver/auth/ssodh/init',
+        expect.stringContaining('compete=true'),
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        })
+      );
+      expect(mockAuthClient.post).toHaveBeenCalledWith(
+        '/iserver/auth/ssodh/init',
+        expect.stringContaining('mac=06-7F-1D-C4-36-2F'),
+        expect.any(Object)
+      );
+      expect(mockAuthClient.post).toHaveBeenCalledWith(
+        '/iserver/auth/ssodh/init',
+        expect.stringContaining('machineId=71a482fc'),
+        expect.any(Object)
+      );
+      expect(mockAuthClient.post).toHaveBeenCalledWith('/iserver/reauthenticate');
+      expect(mockAuthClient.post).toHaveBeenCalledWith('/tickle');
     });
 
-    it('should handle reauth when status returns false', async () => {
+    it('should handle reauth when final status returns false', async () => {
       const mockAuthClient = {
         post: vi.fn().mockResolvedValue({ data: {} }),
-        get: vi.fn().mockResolvedValue({
-          data: { authenticated: false },
-        }),
+        get: vi.fn()
+          .mockResolvedValueOnce({ data: { RESULT: true } })
+          .mockResolvedValueOnce({
+            data: {
+              authenticated: false,
+              connected: true,
+              MAC: '06:7F:1D:C4:36:2F',
+              hardware_info: '71a482fc|06:7F:1D:C4:36:2F',
+            },
+          })
+          .mockRejectedValueOnce(new Error('not ready'))
+          .mockResolvedValueOnce({ data: { authenticated: false, connected: true } }),
       };
 
       vi.mocked(axios.create).mockReturnValueOnce(mockAuthClient as any);
 
       // Should not throw — handled internally
       await expect(client.reauthenticate()).resolves.not.toThrow();
-      expect(mockAuthClient.post).toHaveBeenCalledWith('/iserver/reauthenticate');
+      expect(mockAuthClient.post).toHaveBeenCalledWith(
+        '/iserver/auth/ssodh/init',
+        expect.any(String),
+        expect.any(Object)
+      );
     });
 
     it('should handle network errors gracefully', async () => {
       const mockAuthClient = {
-        post: vi.fn().mockRejectedValue(new Error('Connection refused')),
-        get: vi.fn(),
+        post: vi.fn(),
+        get: vi.fn().mockRejectedValue(new Error('Connection refused')),
       };
 
       vi.mocked(axios.create).mockReturnValueOnce(mockAuthClient as any);
@@ -588,27 +632,29 @@ describe('IBClient', () => {
         vi.mocked(axios.create).mockReturnValueOnce(checkClient as any);
         await client.checkAuthenticationStatus();
 
-        // Capture the tickle axios instance the next time axios.create is called
-        // (startTickle uses axios.create per ping).
         const tickleClient = {
           post: vi.fn().mockResolvedValue({ data: {} }),
         };
-        // Step 2: trigger reauth failure (status=false). reauthenticate() itself
-        // calls axios.create once; subsequent tickle pings (which should NOT happen)
-        // would also call axios.create.
         const reauthClient = {
           post: vi.fn().mockResolvedValue({ data: {} }),
-          get: vi.fn().mockResolvedValue({ data: { authenticated: false } }),
+          get: vi.fn()
+            .mockResolvedValueOnce({ data: { RESULT: true } })
+            .mockResolvedValueOnce({
+              data: {
+                authenticated: false,
+                connected: true,
+                MAC: '06:7F:1D:C4:36:2F',
+                hardware_info: '71a482fc|06:7F:1D:C4:36:2F',
+              },
+            })
+            .mockRejectedValueOnce(new Error('not ready'))
+            .mockResolvedValueOnce({ data: { authenticated: false, connected: true } }),
         };
         vi.mocked(axios.create).mockReturnValueOnce(reauthClient as any);
-        // Any further axios.create calls (e.g., from a stray tickle) would hit this
-        // mock and produce visible POST /tickle calls.
         vi.mocked(axios.create).mockReturnValue(tickleClient as any);
 
         await client.reauthenticate();
 
-        // Advance well past the tickle interval (30s). If tickle were still running
-        // we would see /tickle POSTs against tickleClient.
         await vi.advanceTimersByTimeAsync(120_000);
         expect(tickleClient.post).not.toHaveBeenCalled();
       } finally {
@@ -630,8 +676,8 @@ describe('IBClient', () => {
           post: vi.fn().mockResolvedValue({ data: {} }),
         };
         const reauthClient = {
-          post: vi.fn().mockRejectedValue(new Error('Connection refused')),
-          get: vi.fn(),
+          post: vi.fn(),
+          get: vi.fn().mockRejectedValue(new Error('Connection refused')),
         };
         vi.mocked(axios.create).mockReturnValueOnce(reauthClient as any);
         vi.mocked(axios.create).mockReturnValue(tickleClient as any);


### PR DESCRIPTION
Fix Client Portal Gateway brokerage-session initialization after browser/2FA login.

The current implementation treats `/iserver/reauthenticate` as sufficient and can mark the client authenticated even when `/iserver/auth/status` remains `authenticated:false`. In real Gateway sessions this can leave all `/iserver` endpoints unusable after a successful browser login.

This patch initializes the brokerage session using IBKR's documented SSODH flow:

1. `GET /sso/validate`
2. `GET /iserver/auth/status` to obtain `MAC` and `hardware_info`
3. optional `GET /iserver/accounts` to prime Gateway state
4. `POST /iserver/auth/ssodh/init` with `application/x-www-form-urlencoded` body:
   - `compete=true`
   - `locale=en_US`
   - `mac=<MAC with hyphens>`
   - `machineId=<hardware_info prefix>`
   - `username=-`
5. `POST /iserver/reauthenticate`
6. `POST /tickle`
7. verify final `/iserver/auth/status` before setting authenticated state

It also changes headless auth so the browser page text `Client login succeeds` is not treated as full API readiness when an `IBClient` is available. Instead, it calls `reauthenticate()` and confirms REST brokerage auth.

## Root cause / observed failure

A real Client Portal Gateway login can reach browser success while REST brokerage auth remains false:

```json
{
  "authenticated": false,
  "connected": true,
  "competing": false,
  "fail": "Force compete capability must be used together with compete flag"
}
```

An empty/default `POST /iserver/auth/ssodh/init` may return HTTP 200 but still leave the brokerage session unauthenticated. Sending the documented form body derived from `/iserver/auth/status` makes the session become:

```json
{
  "authenticated": true,
  "established": true,
  "connected": true,
  "competing": false
}
```

## Changes

- Adds a shared raw Axios client helper for auth/tickle requests without interceptors.
- Adds brokerage-session initialization via SSODH form flow.
- Verifies `/iserver/auth/status` before setting `isAuthenticated=true`.
- Stops tickle when reauth fails instead of keeping stale auth state.
- Passes `ibClient` into headless auth so REST brokerage auth can be confirmed.
- Updates tests for the SSODH form body and false-auth cases.

## Validation

Tested locally against a real IBKR Client Portal Gateway session using read-only calls only:

- account info: OK
- positions: OK
- live/open orders: OK, zero open orders in the test account
- market data contract lookup: OK
- no orders placed
- no broker mutations performed

Automated checks:

```bash
npm test
npm run build
```

Both passed locally.