### PR TITLE
fix: preserve specific error messages during authentication

### DIFF
--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -343,9 +343,9 @@ export class IBClient {
       this.isAuthenticated = false;
       this.stopTickle();
       if (this.authAttempts >= this.maxAuthAttempts) {
-        throw new Error(`Failed to authenticate with IB Gateway after ${this.maxAuthAttempts} attempts`);
+        throw new Error(`Failed to authenticate with IB Gateway after ${this.maxAuthAttempts} attempts: ${isError(error) ? error.message : String(error)}`);
       }
-      throw new Error("Failed to authenticate with IB Gateway");
+      throw error;
     }
   }
 


### PR DESCRIPTION
Closes #41. 

This change modifies  to rethrow the original error from the brokerage session initialization instead of swallowing it into a generic string. It also appends the specific error message to the 'max attempts' failure for better diagnostics.