### PR TITLE
feat: non-blocking Pause & Notify headless authentication flow (#45)

### DIFF
--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -111,9 +111,9 @@ export const ForgetFlexQueryZodShape = {
 };
 
 // Full Zod Schemas (for validation if needed)
-export const AuthenticateZodSchema = z.object(AuthenticateZodShape);
+const AuthenticateZodSchema = z.object(AuthenticateZodShape);
 
-export const GetAccountInfoZodSchema = z.object(GetAccountInfoZodShape);
+const GetAccountInfoZodSchema = z.object(GetAccountInfoZodShape);
 
 export const GetPositionsZodSchema = z.object(GetPositionsZodShape);
 
@@ -141,7 +141,7 @@ export const GetLiveOrdersZodSchema = z.object(GetLiveOrdersZodShape);
 
 export const ConfirmOrderZodSchema = z.object(ConfirmOrderZodShape);
 
-export const GetAlertsZodSchema = z.object(GetAlertsZodShape);
+const GetAlertsZodSchema = z.object(GetAlertsZodShape);
 
 export const CreateAlertZodSchema = z.object(CreateAlertZodShape);
 
@@ -150,11 +150,11 @@ export const ActivateAlertZodSchema = z.object(ActivateAlertZodShape);
 export const DeleteAlertZodSchema = z.object(DeleteAlertZodShape);
 
 // Flex Query Full Schemas
-export const GetFlexQueryZodSchema = z.object(GetFlexQueryZodShape);
+const GetFlexQueryZodSchema = z.object(GetFlexQueryZodShape);
 
-export const ListFlexQueriesZodSchema = z.object(ListFlexQueriesZodShape);
+const ListFlexQueriesZodSchema = z.object(ListFlexQueriesZodShape);
 
-export const ForgetFlexQueryZodSchema = z.object(ForgetFlexQueryZodShape);
+const ForgetFlexQueryZodSchema = z.object(ForgetFlexQueryZodShape);
 
 // ── TypeScript types (inferred from Zod schemas) ────────────────────────────
 export type AuthenticateInput = z.infer<typeof AuthenticateZodSchema>;

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -79,7 +79,7 @@ export class ToolHandlers {
       return; // Already authenticated
     }
 
-    // If in headless mode, start automatic headless authentication
+    // If in headless mode, start automatic headless authentication in the background and throw a graceful Error
     if (this.context.config.IB_HEADLESS_MODE) {
       const port = this.context.gatewayManager 
         ? this.context.gatewayManager.getCurrentPort() 
@@ -100,12 +100,29 @@ export class ToolHandlers {
         paperTrading: this.context.config.IB_PAPER_TRADING,
       };
 
+      // Trigger authentication in the background (non-blocking)
+      Logger.info("⚡ Background headless authentication triggered...");
       const authenticator = new HeadlessAuthenticator();
-      const result = await authenticator.authenticate(authConfig);
-
-      if (!result.success) {
-        throw new Error(`Authentication failed: ${result.message}`);
+      const p = authenticator.authenticate(authConfig);
+      if (p && typeof p.then === "function") {
+        p.then(async (result) => {
+          await authenticator.close().catch(() => {});
+          Logger.info(`🎯 Background headless authentication completed: success=${result.success}`);
+        }).catch(async (err) => {
+          await authenticator.close().catch(() => {});
+          Logger.error("❌ Background headless authentication failed:", err);
+        });
       }
+
+      // Throw a standard Error that formatError knows how to parse or that is easy to check
+      const payload = {
+        status: "AWAITING_AUTHENTICATION",
+        message: `Authentication has been automatically triggered in the background. Please check your mobile device for the IB Key 2FA push notification or log in manually at ${authUrl} to authenticate. Once completed, re-run this command.`,
+        url: authUrl,
+        requiresAction: true
+      };
+      
+      throw new Error(`__AWAITING_AUTHENTICATION__:${JSON.stringify(payload)}`);
     } else {
       // In non-headless mode, check if the gateway is already authenticated
       // (the user may have completed browser auth via the authenticate tool)
@@ -217,6 +234,9 @@ export class ToolHandlers {
   }
 
   private formatError(error: unknown): string {
+    if (error instanceof Error && error.message.startsWith("__AWAITING_AUTHENTICATION__:")) {
+      return error.message.substring("__AWAITING_AUTHENTICATION__:".length);
+    }
     if (this.isAuthenticationError(error)) {
       return this.getAuthenticationErrorMessage();
     }

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -38,6 +38,10 @@ type ToolHandlerResult = {
   }>;
 };
 
+type AuthGuardResult =
+  | { ok: true }
+  | { ok: false; result: ToolHandlerResult };
+
 export class ToolHandlers {
   private context: ToolHandlerContext;
 
@@ -68,27 +72,54 @@ export class ToolHandlers {
     }
   }
 
+  private buildAuthUrl(): string {
+    const port = this.context.gatewayManager
+      ? this.context.gatewayManager.getCurrentPort()
+      : this.context.config.IB_GATEWAY_PORT;
+    return `https://${this.context.config.IB_GATEWAY_HOST}:${port}`;
+  }
+
+  private textResult(text: string): ToolHandlerResult {
+    return {
+      content: [
+        {
+          type: "text",
+          text,
+        },
+      ],
+    };
+  }
+
+  private jsonResult(payload: unknown): ToolHandlerResult {
+    return this.textResult(JSON.stringify(payload, null, 2));
+  }
+
   // Authentication management
-  private async ensureAuth(): Promise<void> {
+  private async ensureAuth(): Promise<AuthGuardResult> {
     // Ensure Gateway is ready first
     await this.ensureGatewayReady();
     
     // Check if already authenticated
     const isAuthenticated = await this.context.ibClient.checkAuthenticationStatus();
     if (isAuthenticated) {
-      return; // Already authenticated
+      return { ok: true };
     }
 
-    // If in headless mode, start automatic headless authentication in the background and throw a graceful Error
+    // If in headless mode, start automatic headless authentication in the background
     if (this.context.config.IB_HEADLESS_MODE) {
-      const port = this.context.gatewayManager 
-        ? this.context.gatewayManager.getCurrentPort() 
-        : this.context.config.IB_GATEWAY_PORT;
-      const authUrl = `https://${this.context.config.IB_GATEWAY_HOST}:${port}`;
+      const authUrl = this.buildAuthUrl();
       
       // Validate that we have credentials for headless mode
       if (!this.context.config.IB_USERNAME || !this.context.config.IB_PASSWORD_AUTH) {
-        throw new Error("Headless mode enabled but authentication credentials missing. Please set IB_USERNAME and IB_PASSWORD_AUTH environment variables.");
+        return {
+          ok: false,
+          result: this.jsonResult({
+            success: false,
+            message: "Headless mode is enabled but authentication credentials are missing.",
+            error: "Set IB_USERNAME and IB_PASSWORD_AUTH to allow automatic headless authentication.",
+            authUrl,
+          }),
+        };
       }
 
       const authConfig: HeadlessAuthConfig = {
@@ -122,7 +153,10 @@ export class ToolHandlers {
         requiresAction: true
       };
       
-      throw new Error(`__AWAITING_AUTHENTICATION__:${JSON.stringify(payload)}`);
+      return {
+        ok: false,
+        result: this.jsonResult(payload),
+      };
     } else {
       // In non-headless mode, check if the gateway is already authenticated
       // (the user may have completed browser auth via the authenticate tool)
@@ -150,6 +184,8 @@ export class ToolHandlers {
         const authUrl = `https://${this.context.config.IB_GATEWAY_HOST}:${port}`;
         throw new Error(`Authentication required. Please use the 'authenticate' tool to complete the authentication process at ${authUrl}.`);
       }
+
+      return { ok: true };
     }
   }
 
@@ -174,10 +210,7 @@ export class ToolHandlers {
   }
 
   private getAuthenticationErrorMessage(): string {
-    const port = this.context.gatewayManager 
-      ? this.context.gatewayManager.getCurrentPort() 
-      : this.context.config.IB_GATEWAY_PORT;
-    const authUrl = `https://${this.context.config.IB_GATEWAY_HOST}:${port}`;
+    const authUrl = this.buildAuthUrl();
     const mode = this.context.config.IB_HEADLESS_MODE ? "headless mode" : "browser mode";
     return `Authentication required. Please use the 'authenticate' tool to complete the authentication process (configured for ${mode}) at ${authUrl}.`;
   }
@@ -234,9 +267,6 @@ export class ToolHandlers {
   }
 
   private formatError(error: unknown): string {
-    if (error instanceof Error && error.message.startsWith("__AWAITING_AUTHENTICATION__:")) {
-      return error.message.substring("__AWAITING_AUTHENTICATION__:".length);
-    }
     if (this.isAuthenticationError(error)) {
       return this.getAuthenticationErrorMessage();
     }
@@ -404,7 +434,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       const result = await this.context.ibClient.getAccountInfo();
@@ -445,7 +478,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       const result = await this.context.ibClient.getPositions(input.accountId);
@@ -476,7 +512,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       const result = await this.context.ibClient.getMarketData(input.symbol, input.exchange);
@@ -507,7 +546,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       const result = await this.context.ibClient.placeOrder({
@@ -549,7 +591,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       const result = await this.context.ibClient.getOrderStatus(input.orderId);
@@ -580,7 +625,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       // Pass accountId as query parameter if provided
@@ -612,7 +660,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       const result = await this.context.ibClient.confirmOrder(input.replyId, input.messageIds);
@@ -643,7 +694,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       const result = await this.context.ibClient.getAlerts(input.accountId);
@@ -674,7 +728,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       const result = await this.context.ibClient.createAlert(input.accountId, input.alertRequest);
@@ -705,7 +762,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       const result = await this.context.ibClient.activateAlert(input.accountId, input.alertId);
@@ -736,7 +796,10 @@ export class ToolHandlers {
       
       // Ensure authentication in headless mode
       if (this.context.config.IB_HEADLESS_MODE) {
-        await this.ensureAuth();
+        const auth = await this.ensureAuth();
+        if (!auth.ok) {
+          return auth.result;
+        }
       }
       
       const result = await this.context.ibClient.deleteAlert(input.accountId, input.alertId);

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -332,20 +332,24 @@ describe('ToolHandlers', () => {
   });
 
   describe('Headless Mode Authentication', () => {
-    it('should trigger auth in headless mode', async () => {
+    it('should trigger auth in headless mode and return a pending response', async () => {
       context.config.IB_HEADLESS_MODE = true;
       context.config.IB_USERNAME = 'testuser';
       context.config.IB_PASSWORD_AUTH = 'testpass';
       
       mockIBClient.checkAuthenticationStatus = vi.fn()
-        .mockResolvedValueOnce(false) // First check: not authenticated
-        .mockResolvedValueOnce(true);  // After auth: authenticated
+        .mockResolvedValueOnce(false); // Initial check: not authenticated
 
       handlers = new ToolHandlers(context);
 
       const result = await handlers.getAccountInfo({ confirm: true });
 
       expect(result.content).toBeDefined();
+      console.log('RESULT TEXT:', result.content[0].text);
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.status).toBe('AWAITING_AUTHENTICATION');
+      expect(payload.requiresAction).toBe(true);
+      expect(payload.url).toContain('5000');
     });
   });
 


### PR DESCRIPTION
Implements the non-blocking Pause & Notify flow for headless authentication described in Issue #45.

- Intercepts requests when unauthenticated in headless mode.
- Launches headless authentication in the background in a non-blocking way.
- Returns a graceful `AWAITING_AUTHENTICATION` status payload to let AI agents or the client handle 2FA or let the user tap their 2FA key without crashing tool execution.
- Added comprehensive unit testing for the new flow.