### PR TITLE
Fix gateway reuse when existing IB Gateway is unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ For a complete guide on creating and customizing Flex Queries, see the [IB Flex 
 | Headless Mode | `IB_HEADLESS_MODE` | `--ib-headless-mode` |
 | Paper Trading | `IB_PAPER_TRADING` | `--ib-paper-trading` |
 | Auth Timeout | `IB_AUTH_TIMEOUT` | `--ib-auth-timeout` |
+| Force standalone bundled gateway | `IB_FORCE_STANDALONE_GATEWAY` | N/A |
 | Flex Token | `IB_FLEX_TOKEN` | N/A |
 | Read-only mode | `IB_READ_ONLY_MODE` | `--ib-read-only-mode` |
 
@@ -216,6 +217,11 @@ For a complete guide on creating and customizing Flex Queries, see the [IB Flex 
 - Use the web interface that opens automatically
 - Complete any required two-factor authentication
 - Try paper trading mode if live trading fails
+
+**Gateway Discovery Problems:**
+
+- If another IB Gateway is already listening on a local port but should not be reused, set `IB_FORCE_STANDALONE_GATEWAY=true`
+- Existing gateways are only reused when the MCP process can reach them over HTTPS; otherwise the bundled standalone gateway is started on an available port
 
 ## Support
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ dotenvConfig();
 export const config = {
   IB_GATEWAY_HOST: process.env.IB_GATEWAY_HOST || "localhost",
   IB_GATEWAY_PORT: parseInt(process.env.IB_GATEWAY_PORT || "5000"),
+  IB_FORCE_STANDALONE_GATEWAY: process.env.IB_FORCE_STANDALONE_GATEWAY === "true",
   IB_ACCOUNT: process.env.IB_ACCOUNT || "",
   IB_PASSWORD: process.env.IB_PASSWORD || "",
 

--- a/src/gateway-manager.ts
+++ b/src/gateway-manager.ts
@@ -29,11 +29,13 @@ export class IBGatewayManager {
   private backgroundStartupPromise: Promise<void> | null = null;
   private spawnFailure: { reason: string; details?: string } | null = null;
   private static readonly STDERR_TAIL_BYTES = 4096;
+  private readonly forceStandaloneGateway: boolean;
 
   constructor() {
     this.gatewayDir = path.join(__dirname, '../ib-gateway');
     this.jreDir = path.join(__dirname, '../runtime');
     this.useStderr = !(process.env.MCP_HTTP_SERVER === 'true' || process.argv.includes('--http'));
+    this.forceStandaloneGateway = process.env.IB_FORCE_STANDALONE_GATEWAY === 'true';
     this.registerCleanupHandlers();
   }
 
@@ -44,8 +46,19 @@ export class IBGatewayManager {
 
 
   private async findExistingGateway(): Promise<number | null> {
+    if (this.forceStandaloneGateway) {
+      this.log('Standalone gateway mode enabled; skipping existing gateway discovery');
+      return null;
+    }
     this.log('🔍 Checking for existing Gateway instances...');
     const existingPort = await PortUtils.findExistingGateway();
+    if (existingPort) {
+      const isReachable = await this.checkGatewayHealth(existingPort);
+      if (!isReachable) {
+        this.log(`Gateway candidate on port ${existingPort} is not reachable; ignoring it`);
+        return null;
+      }
+    }
     if (existingPort) {
       this.log(`✅ Found existing Gateway on port ${existingPort}`);
     } else {
@@ -55,9 +68,20 @@ export class IBGatewayManager {
   }
 
   async quickCheckExistingGateway(): Promise<number | null> {
+    if (this.forceStandaloneGateway) {
+      this.log('Standalone gateway mode enabled; skipping quick existing gateway discovery');
+      return null;
+    }
     this.log('⚡ Quick check for existing Gateway instances...');
     try {
       const existingPort = await PortUtils.findExistingGateway();
+      if (existingPort) {
+        const isReachable = await this.checkGatewayHealth(existingPort);
+        if (!isReachable) {
+          this.log(`Gateway candidate on port ${existingPort} is not reachable; ignoring it`);
+          return null;
+        }
+      }
       if (existingPort) {
         this.log(`✅ Found existing Gateway on port ${existingPort}`);
       } else {
@@ -518,7 +542,7 @@ export class IBGatewayManager {
 
       try {
         // Try to connect to the gateway port
-        const response = await this.checkGatewayHealth();
+        const response = await this.checkGatewayHealth(this.currentPort);
         if (response) {
           this.log(`✅ IB Gateway is responding on port ${this.currentPort}`);
           return;
@@ -561,14 +585,14 @@ export class IBGatewayManager {
     return `Failed to spawn IB Gateway: ${error.message}`;
   }
 
-  private async checkGatewayHealth(): Promise<boolean> {
+  private async checkGatewayHealth(port: number = this.currentPort): Promise<boolean> {
     // Import https dynamically to avoid issues with module resolution
     const https = await import('https');
     
     return new Promise((resolve, reject) => {
       const options = {
         hostname: 'localhost',
-        port: this.currentPort,
+        port,
         path: '/',
         method: 'GET',
         rejectUnauthorized: false, // Accept self-signed certificates

--- a/test/gateway-manager.test.ts
+++ b/test/gateway-manager.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as fs from 'fs';
 import { IBGatewayManager } from '../src/gateway-manager.js';
+import { PortUtils } from '../src/utils/port-utils.js';
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof fs>('fs');
@@ -91,5 +92,59 @@ describe('IBGatewayManager runtime platform resolution', () => {
     expect((IBGatewayManager as unknown as {
       resolveRuntimePlatform: (platform?: NodeJS.Platform, arch?: string) => string;
     }).resolveRuntimePlatform('linux', 'arm64')).toBe('linux-arm64-musl');
+  });
+});
+
+describe('IBGatewayManager existing gateway selection', () => {
+  const originalForceStandalone = process.env.IB_FORCE_STANDALONE_GATEWAY;
+
+  afterEach(() => {
+    if (originalForceStandalone === undefined) {
+      delete process.env.IB_FORCE_STANDALONE_GATEWAY;
+    } else {
+      process.env.IB_FORCE_STANDALONE_GATEWAY = originalForceStandalone;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('skips existing gateway discovery when standalone mode is forced', async () => {
+    process.env.IB_FORCE_STANDALONE_GATEWAY = 'true';
+    const findExistingGatewaySpy = vi.spyOn(PortUtils, 'findExistingGateway');
+    const manager = new IBGatewayManager();
+
+    const port = await manager.quickCheckExistingGateway();
+
+    expect(port).toBeNull();
+    expect(findExistingGatewaySpy).not.toHaveBeenCalled();
+  });
+
+  it('ignores an existing gateway candidate when it is not reachable', async () => {
+    process.env.IB_FORCE_STANDALONE_GATEWAY = 'false';
+    vi.spyOn(PortUtils, 'findExistingGateway').mockResolvedValue(5000);
+    const manager = new IBGatewayManager() as unknown as {
+      quickCheckExistingGateway: () => Promise<number | null>;
+      checkGatewayHealth: (port?: number) => Promise<boolean>;
+    };
+    const checkGatewayHealthSpy = vi.spyOn(manager, 'checkGatewayHealth').mockResolvedValue(false);
+
+    const port = await manager.quickCheckExistingGateway();
+
+    expect(port).toBeNull();
+    expect(checkGatewayHealthSpy).toHaveBeenCalledWith(5000);
+  });
+
+  it('reuses an existing gateway candidate when it is reachable', async () => {
+    process.env.IB_FORCE_STANDALONE_GATEWAY = 'false';
+    vi.spyOn(PortUtils, 'findExistingGateway').mockResolvedValue(5000);
+    const manager = new IBGatewayManager() as unknown as {
+      quickCheckExistingGateway: () => Promise<number | null>;
+      checkGatewayHealth: (port?: number) => Promise<boolean>;
+    };
+    const checkGatewayHealthSpy = vi.spyOn(manager, 'checkGatewayHealth').mockResolvedValue(true);
+
+    const port = await manager.quickCheckExistingGateway();
+
+    expect(port).toBe(5000);
+    expect(checkGatewayHealthSpy).toHaveBeenCalledWith(5000);
   });
 });


### PR DESCRIPTION
## Summary
- add `IB_FORCE_STANDALONE_GATEWAY` to skip existing gateway reuse entirely
- require an HTTPS reachability check before reusing a discovered local IB Gateway
- document the new override and add tests for reachable vs unreachable candidates

## Problem
Gateway discovery currently treats a matching process on a common port as reusable too early. That can incorrectly adopt another IB Gateway already running in Docker or another environment even when this MCP process cannot actually talk to it.

## Validation
- `npm test`
- `npx tsc --noEmit`

Closes #48
