### PR TITLE
fix: prevent headless auth loop lock on unauthenticated cached cookies

### DIFF
--- a/src/headless-auth.ts
+++ b/src/headless-auth.ts
@@ -99,6 +99,9 @@ export class HeadlessAuthenticator {
       Logger.info('🔄 Submitting login form...');
       await this.page.click(submitSelector);
 
+      // Indicate that credentials form was filled and successfully submitted
+      let credentialsSubmitted = true;
+
       // Wait for the authentication process to complete using IB client polling
       Logger.info('⏳ Waiting for authentication to complete...');
       
@@ -132,7 +135,7 @@ export class HeadlessAuthenticator {
           const currentUrl = this.page.url();
           const pageContent = await this.page.content();
 
-          if (authConfig.ibClient) {
+          if (authConfig.ibClient && credentialsSubmitted) {
             const cookies = await this.page.context().cookies();
             authConfig.ibClient.setSessionCookies(cookies);
           }


### PR DESCRIPTION
The HeadlessAuthenticator was entering its 2FA awaiting loop immediately if ANY localhost cookies were present, even if those cookies were unauthenticated defaults dropped during landing page load. This prevented credentials from actually being typed or submitted, locking the session on a blank screen.

Added a strict state-gate (credentialsSubmitted) to ensure that the headless authenticator only initializes and sets session cookies after the username and password form has actually been successfully filled out and submitted.

This resolves the false-positive 2FA loop locks and allows the background authenticator to correctly prompt push notifications.