### PR TITLE
fix: reuse gateway and clarify headless auth states

### DIFF
--- a/src/browser-installer.ts
+++ b/src/browser-installer.ts
@@ -1,6 +1,8 @@
 import { chromium, Browser } from 'playwright-core';
 import { Logger } from './logger.js';
 import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 export class BrowserInstaller {
   static headless: boolean = true; // Set this to false to debug 
@@ -69,7 +71,49 @@ export class BrowserInstaller {
       }
     }
 
+    const playwrightBrowserPath = await this.findPlaywrightCacheBrowser();
+    if (playwrightBrowserPath) {
+      Logger.info(`🔍 Found Playwright cached browser: ${playwrightBrowserPath}`);
+      return playwrightBrowserPath;
+    }
+
     Logger.warn('⚠️ No system browser found, will try Playwright default');
+    return null;
+  }
+
+  private static async findPlaywrightCacheBrowser(): Promise<string | null> {
+    const cacheRoots = [
+      process.env.PLAYWRIGHT_BROWSERS_PATH,
+      path.join(os.homedir(), '.cache', 'ms-playwright'),
+    ].filter(Boolean) as string[];
+
+    for (const cacheRoot of cacheRoots) {
+      let entries: string[];
+      try {
+        entries = await fs.promises.readdir(cacheRoot);
+      } catch {
+        continue;
+      }
+
+      const chromiumDirs = entries
+        .filter((entry) => entry.startsWith('chromium-'))
+        .sort()
+        .reverse();
+
+      for (const entry of chromiumDirs) {
+        const candidates = [
+          path.join(cacheRoot, entry, 'chrome-linux64', 'chrome'),
+          path.join(cacheRoot, entry, 'chrome-linux', 'chrome'),
+        ];
+
+        for (const candidate of candidates) {
+          if (await this.isExecutableFile(candidate)) {
+            return candidate;
+          }
+        }
+      }
+    }
+
     return null;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ export const config = {
   // Headless authentication configuration
   IB_USERNAME: process.env.IB_USERNAME || "",
   IB_PASSWORD_AUTH: process.env.IB_PASSWORD_AUTH || process.env.IB_PASSWORD || "",
-  IB_AUTH_TIMEOUT: parseInt(process.env.IB_AUTH_TIMEOUT || "60000"),
+  IB_AUTH_TIMEOUT: parseInt(process.env.IB_AUTH_TIMEOUT || "300000"),
   IB_HEADLESS_MODE: process.env.IB_HEADLESS_MODE === "true",
 
   // Paper trading configuration

--- a/src/gateway-manager.ts
+++ b/src/gateway-manager.ts
@@ -25,10 +25,17 @@ export class IBGatewayManager {
   private isReady = false;
   private useStderr: boolean;
   private cleanupHandlersRegistered = false;
-  private currentPort: number = 5000;
+  private currentPort: number = IBGatewayManager.getConfiguredGatewayPort();
   private backgroundStartupPromise: Promise<void> | null = null;
   private spawnFailure: { reason: string; details?: string } | null = null;
   private static readonly STDERR_TAIL_BYTES = 4096;
+  private static readonly DEFAULT_GATEWAY_PORT = 5000;
+  private static readonly COMMON_GATEWAY_PORTS = [5000, 5001, 5002, 5003, 5004, 5005];
+  private static readonly GATEWAY_HEALTH_PATHS = [
+    '/v1/api/iserver/auth/status',
+    '/v1/api/tickle',
+    '/',
+  ];
   private readonly forceStandaloneGateway: boolean;
 
   constructor() {
@@ -45,12 +52,45 @@ export class IBGatewayManager {
 
 
 
+  private static getConfiguredGatewayPort(): number {
+    const parsedPort = Number.parseInt(process.env.IB_GATEWAY_PORT || '', 10);
+    return Number.isFinite(parsedPort) && parsedPort > 0
+      ? parsedPort
+      : IBGatewayManager.DEFAULT_GATEWAY_PORT;
+  }
+
+  private getGatewayProbePorts(): number[] {
+    return Array.from(new Set([
+      this.currentPort,
+      IBGatewayManager.getConfiguredGatewayPort(),
+      ...IBGatewayManager.COMMON_GATEWAY_PORTS,
+    ].filter((port) => Number.isInteger(port) && port > 0 && port < 65536)));
+  }
+
+  private async findReachableGatewayPort(): Promise<number | null> {
+    for (const port of this.getGatewayProbePorts()) {
+      const isReachable = await this.checkGatewayHealth(port);
+      if (isReachable) {
+        return port;
+      }
+    }
+
+    return null;
+  }
+
   private async findExistingGateway(): Promise<number | null> {
     if (this.forceStandaloneGateway) {
       this.log('Standalone gateway mode enabled; skipping existing gateway discovery');
       return null;
     }
     this.log('🔍 Checking for existing Gateway instances...');
+
+    const reachablePort = await this.findReachableGatewayPort();
+    if (reachablePort) {
+      this.log(`✅ Found reachable Gateway on port ${reachablePort}`);
+      return reachablePort;
+    }
+
     const existingPort = await PortUtils.findExistingGateway();
     if (existingPort) {
       const isReachable = await this.checkGatewayHealth(existingPort);
@@ -74,6 +114,12 @@ export class IBGatewayManager {
     }
     this.log('⚡ Quick check for existing Gateway instances...');
     try {
+      const reachablePort = await this.findReachableGatewayPort();
+      if (reachablePort) {
+        this.log(`✅ Found reachable Gateway on port ${reachablePort}`);
+        return reachablePort;
+      }
+
       const existingPort = await PortUtils.findExistingGateway();
       if (existingPort) {
         const isReachable = await this.checkGatewayHealth(existingPort);
@@ -399,7 +445,7 @@ export class IBGatewayManager {
       
       // Check port availability for new Gateway
       this.log('🔍 Checking port availability for new Gateway...');
-      const defaultPort = 5000;
+      const defaultPort = IBGatewayManager.getConfiguredGatewayPort();
       
       if (await PortUtils.isPortAvailable(defaultPort)) {
         this.currentPort = defaultPort;
@@ -453,6 +499,7 @@ export class IBGatewayManager {
         '--conf', `../${configFile}`
       ], {
         cwd: path.join(this.gatewayDir, 'clientportal.gw'),
+        detached: true,
         env: {
           ...process.env,
           JAVA_HOME: bundledJavaHome,
@@ -460,6 +507,8 @@ export class IBGatewayManager {
         },
         stdio: ['ignore', 'pipe', 'pipe']
       });
+
+      this.gatewayProcess.unref();
 
       // Buffer the tail of stderr so we can include it in a failure reason if the process
       // dies before the gateway's HTTP port comes up.
@@ -585,22 +634,54 @@ export class IBGatewayManager {
     return `Failed to spawn IB Gateway: ${error.message}`;
   }
 
-  private async checkGatewayHealth(port: number = this.currentPort): Promise<boolean> {
-    // Import https dynamically to avoid issues with module resolution
-    const https = await import('https');
-    
-    return new Promise((resolve, reject) => {
+  private isLiveGatewayResponse(pathname: string, statusCode?: number): boolean {
+    if (!statusCode) {
+      return false;
+    }
+
+    if (pathname.startsWith('/v1/api/')) {
+      // Unauthenticated Client Portal Gateway API endpoints commonly return 401.
+      // That still proves the Gateway is alive and should be reused.
+      return (
+        statusCode === 200 ||
+        statusCode === 204 ||
+        statusCode === 302 ||
+        statusCode === 401 ||
+        statusCode === 403 ||
+        statusCode === 405
+      );
+    }
+
+    return (
+      statusCode === 200 ||
+      statusCode === 301 ||
+      statusCode === 302 ||
+      statusCode === 303 ||
+      statusCode === 307 ||
+      statusCode === 308 ||
+      statusCode === 401 ||
+      statusCode === 403
+    );
+  }
+
+  private async probeGatewayEndpoint(
+    https: typeof import('https'),
+    port: number,
+    pathname: string,
+  ): Promise<boolean> {
+    return new Promise((resolve) => {
       const options = {
         hostname: 'localhost',
         port,
-        path: '/',
+        path: pathname,
         method: 'GET',
         rejectUnauthorized: false, // Accept self-signed certificates
-        timeout: 5000
+        timeout: 5000,
       };
 
       const req = https.request(options, (res) => {
-        resolve(res.statusCode === 200 || res.statusCode === 401 || res.statusCode === 302);
+        res.resume();
+        resolve(this.isLiveGatewayResponse(pathname, res.statusCode));
       });
 
       req.on('error', () => {
@@ -616,6 +697,20 @@ export class IBGatewayManager {
     });
   }
 
+  private async checkGatewayHealth(port: number = this.currentPort): Promise<boolean> {
+    // Import https dynamically to avoid issues with module resolution
+    const https = await import('https');
+
+    for (const pathname of IBGatewayManager.GATEWAY_HEALTH_PATHS) {
+      const isReachable = await this.probeGatewayEndpoint(https, port, pathname);
+      if (isReachable) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   async stopGateway(): Promise<void> {
     // Don't actually stop the gateway - just disconnect from it
     this.log('🔗 Disconnecting from IB Gateway (leaving it running)...');
@@ -628,7 +723,7 @@ export class IBGatewayManager {
   }
 
   isGatewayReady(): boolean {
-    return this.isReady && this.gatewayProcess !== null;
+    return this.isReady;
   }
 
   getGatewayUrl(): string {

--- a/src/headless-auth.ts
+++ b/src/headless-auth.ts
@@ -15,13 +15,41 @@ export interface HeadlessAuthConfig {
 interface HeadlessAuthResult {
   success: boolean;
   message: string;
+  status?: 'SUCCESS' | 'WAITING_FOR_USER_2FA' | 'AUTH_FAILED' | 'TIMEOUT' | 'ERROR';
   waitingFor2FA?: boolean;
+  pushDelivered?: boolean;
+  browserKeptOpen?: boolean;
+  twoFactorMethod?: string;
   error?: string;
+}
+
+interface AuthenticationFailureState {
+  detected: boolean;
+  message?: string;
 }
 
 export class HeadlessAuthenticator {
   private browser: Browser | null = null;
   private page: Page | null = null;
+
+  private buildWaitingFor2FAResult(
+    twoFactorState: { message?: string; method?: string },
+    timeoutMs: number,
+  ): HeadlessAuthResult {
+    const pushDelivered = twoFactorState.method === 'ibkr_mobile_push';
+    return {
+      success: false,
+      status: 'WAITING_FOR_USER_2FA',
+      waitingFor2FA: true,
+      pushDelivered,
+      browserKeptOpen: true,
+      twoFactorMethod: twoFactorState.method,
+      message: pushDelivered
+        ? `${twoFactorState.message}. The browser session has been left open so mobile approval can still complete.`
+        : `${twoFactorState.message}. The browser session has been left open so you can complete this step.`,
+      error: `Timed out after ${Math.round(timeoutMs / 1000)}s while waiting for user two-factor authentication`,
+    };
+  }
 
   async authenticate(authConfig: HeadlessAuthConfig): Promise<HeadlessAuthResult> {
     try {
@@ -49,13 +77,25 @@ export class HeadlessAuthenticator {
       Logger.info('⏳ Waiting for login form...');
       await this.page.waitForSelector('input[name="user"], input[id="user"], input[type="text"]', { timeout: 30000 });
 
-      // Find and fill username field
-      const usernameSelector = 'input[name="user"], input[id="user"], input[type="text"]';
+      // IBKR periodically changes exact login field names. Prefer the current
+      // stable ids/names, then fall back to a visible text input.
+      const usernameSelector = [
+        'input#xyz-field-username',
+        'input[name="username"]',
+        'input[name="user"]',
+        'input[id="user"]',
+        'input[type="text"]:visible',
+      ].join(', ');
       await this.page.fill(usernameSelector, authConfig.username);
       Logger.info('✅ Username filled');
 
       // Find and fill password field
-      const passwordSelector = 'input[name="password"], input[id="password"], input[type="password"]';
+      const passwordSelector = [
+        'input#xyz-field-password',
+        'input[name="password"]',
+        'input[id="password"]',
+        'input[type="password"]:visible',
+      ].join(', ');
       await this.page.fill(passwordSelector, authConfig.password);
       Logger.info('✅ Password filled');
 
@@ -122,6 +162,7 @@ export class HeadlessAuthenticator {
               
               return {
                 success: true,
+                status: 'SUCCESS',
                 message: 'Headless authentication completed successfully. IB Client confirmed authentication.'
               };
             }
@@ -158,6 +199,7 @@ export class HeadlessAuthenticator {
 
                     return {
                       success: true,
+                      status: 'SUCCESS',
                       message: 'Headless authentication completed successfully. Brokerage session initialized.'
                     };
                   }
@@ -173,22 +215,28 @@ export class HeadlessAuthenticator {
 
               return {
                 success: true,
+                status: 'SUCCESS',
                 message: 'Headless browser login completed. No IB client was provided to verify REST brokerage authentication.'
               };
             }
           }
 
-          // Check for potential 2FA or other intermediate states
-          const has2FAIndicators = 
-            pageContent.includes('two-factor') ||
-            pageContent.includes('2FA') ||
-            pageContent.includes('authentication') ||
-            pageContent.includes('verification') ||
-            pageContent.includes('code') ||
-            currentUrl.includes('sso');
+          const authFailureState = await this.detectAuthenticationFailureState();
+          if (authFailureState.detected) {
+            Logger.warn(`❌ ${authFailureState.message}`);
+            await this.cleanup();
+            return {
+              success: false,
+              status: 'AUTH_FAILED',
+              message: 'IBKR rejected the submitted login credentials or authentication attempt.',
+              error: authFailureState.message,
+            };
+          }
 
-          if (has2FAIndicators) {
-            Logger.info('🔐 Two-factor authentication detected - continuing to wait...');
+          const twoFactorState = await this.detectTwoFactorState();
+
+          if (twoFactorState.detected) {
+            Logger.info(`🔐 ${twoFactorState.message} - continuing to wait...`);
           } else {
             Logger.info(`🔍 Still waiting for authentication completion... (${Math.round((Date.now() - startTime) / 1000)}s elapsed)`);
           }
@@ -198,11 +246,19 @@ export class HeadlessAuthenticator {
         }
       }
 
-      // Timeout reached without seeing success message
+      const finalTwoFactorState: { detected: boolean; message?: string; method?: string } =
+        await this.detectTwoFactorState().catch(() => ({ detected: false }));
+      if (finalTwoFactorState.detected) {
+        Logger.warn(`⏰ Authentication timeout reached while ${finalTwoFactorState.message}`);
+        return this.buildWaitingFor2FAResult(finalTwoFactorState, maxWaitTime);
+      }
+
       Logger.warn('⏰ Authentication timeout reached without seeing "Client login succeeds"');
+      await this.cleanup();
       
       return {
         success: false,
+        status: 'TIMEOUT',
         message: 'Authentication timeout. Did not detect "Client login succeeds" message within the timeout period.',
         error: 'Authentication timeout - success message not detected'
       };
@@ -221,10 +277,113 @@ export class HeadlessAuthenticator {
       
       return {
         success: false,
+        status: 'ERROR',
         message: 'Headless authentication failed',
         error: `${errorMessage}\n\nStack trace:\n${errorDetails}\n\nEnvironment: ${process.platform}-${process.arch}, Node: ${process.version}`
       };
     }
+  }
+
+  private async detectAuthenticationFailureState(): Promise<AuthenticationFailureState> {
+    if (!this.page) {
+      return { detected: false };
+    }
+
+    const state = await this.page.evaluate(() => {
+      const doc = (globalThis as any).document;
+      const visibleText = (doc.body?.innerText || '').replace(/\s+/g, ' ').trim();
+      const visibleAlerts = [...doc.querySelectorAll('[role="alert"], .error, .alert, .message, .xyz-error')]
+        .filter((el: any) => Boolean(el.offsetWidth || el.offsetHeight || el.getClientRects().length))
+        .map((el: any) => (el.innerText || el.textContent || '').trim())
+        .join(' ');
+
+      return { visibleText, visibleAlerts };
+    });
+
+    const text = `${state.visibleText} ${state.visibleAlerts}`.toLowerCase();
+    const failureIndicators = [
+      'invalid username',
+      'invalid password',
+      'incorrect username',
+      'incorrect password',
+      'invalid credentials',
+      'credentials are invalid',
+      'username or password',
+      'login failed',
+      'authentication failed',
+      'account is locked',
+      'too many failed',
+    ];
+    const matchedIndicator = failureIndicators.find((indicator) => text.includes(indicator));
+
+    if (!matchedIndicator) {
+      return { detected: false };
+    }
+
+    return {
+      detected: true,
+      message: `IBKR login page reported ${matchedIndicator}`,
+    };
+  }
+
+  private async detectTwoFactorState(): Promise<{ detected: boolean; message?: string; method?: string }> {
+    if (!this.page) {
+      return { detected: false };
+    }
+
+    const state = await this.page.evaluate(() => {
+      const doc = (globalThis as any).document;
+      const visibleText = (doc.body?.innerText || '').replace(/\s+/g, ' ').trim();
+      const visibleButtons = [...doc.querySelectorAll('button, input[type="submit"], input[type="button"]')]
+        .filter((el: any) => Boolean(el.offsetWidth || el.offsetHeight || el.getClientRects().length))
+        .map((el: any) => (el.innerText || el.value || '').trim())
+        .join(' ');
+
+      return { visibleText, visibleButtons };
+    });
+
+    const text = `${state.visibleText} ${state.visibleButtons}`.toLowerCase();
+    if (text.includes('open the ibkr notification') || text.includes('sent you a notification')) {
+      return {
+        detected: true,
+        method: 'ibkr_mobile_push',
+        message: 'IBKR reports that it sent a mobile notification and is waiting for approval'
+      };
+    }
+
+    if (text.includes('resend notification')) {
+      return {
+        detected: true,
+        method: 'ibkr_mobile_push',
+        message: 'IBKR is showing the mobile notification approval screen'
+      };
+    }
+
+    if (text.includes('temporary security code') || text.includes('security code') || text.includes('response code')) {
+      return {
+        detected: true,
+        method: 'security_code',
+        message: 'IBKR is waiting for a security code challenge response'
+      };
+    }
+
+    if (text.includes('select second factor device') || text.includes('text voice email')) {
+      return {
+        detected: true,
+        method: 'factor_selection',
+        message: 'IBKR is waiting for second-factor method selection'
+      };
+    }
+
+    if (text.includes('two-factor') || text.includes('2fa') || text.includes('verification')) {
+      return {
+        detected: true,
+        method: 'unknown_2fa',
+        message: 'IBKR is waiting on a two-factor authentication step'
+      };
+    }
+
+    return { detected: false };
   }
 
 
@@ -233,6 +392,7 @@ export class HeadlessAuthenticator {
     if (!this.page) {
       return {
         success: false,
+        status: 'ERROR',
         message: 'No active browser session',
         error: 'Browser session not found'
       };
@@ -254,6 +414,7 @@ export class HeadlessAuthenticator {
               
               return {
                 success: true,
+                status: 'SUCCESS',
                 message: 'Authentication completed successfully. IB Client confirmed authentication.'
               };
             }
@@ -281,6 +442,7 @@ export class HeadlessAuthenticator {
                   await this.cleanup();
                   return {
                     success: true,
+                    status: 'SUCCESS',
                     message: 'Authentication completed successfully. Brokerage session initialized.'
                   };
                 }
@@ -295,7 +457,19 @@ export class HeadlessAuthenticator {
             
             return {
               success: true,
+              status: 'SUCCESS',
               message: 'Authentication completed successfully. Client login succeeds message detected, but REST auth was not verified because no IB client was provided.'
+            };
+          }
+
+          const authFailureState = await this.detectAuthenticationFailureState();
+          if (authFailureState.detected) {
+            await this.cleanup();
+            return {
+              success: false,
+              status: 'AUTH_FAILED',
+              message: 'IBKR rejected the login credentials or authentication attempt.',
+              error: authFailureState.message,
             };
           }
         } catch (pageError) {
@@ -308,10 +482,17 @@ export class HeadlessAuthenticator {
 
       // Timeout reached
       Logger.warn('⏰ 2FA timeout reached');
+      const finalTwoFactorState: { detected: boolean; message?: string; method?: string } =
+        await this.detectTwoFactorState().catch(() => ({ detected: false }));
+      if (finalTwoFactorState.detected) {
+        return this.buildWaitingFor2FAResult(finalTwoFactorState, maxWaitTime);
+      }
+
       await this.cleanup();
       
       return {
         success: false,
+        status: 'TIMEOUT',
         message: 'Two-factor authentication timeout. Please try again.',
         error: 'Authentication timeout'
       };
@@ -325,6 +506,7 @@ export class HeadlessAuthenticator {
       
       return {
         success: false,
+        status: 'ERROR',
         message: 'Error while waiting for two-factor authentication',
         error: `${errorMessage}\n\nStack trace:\n${errorDetails}`
       };

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -381,6 +381,11 @@ export class IBClient {
       }
 
       await sleep(1000);
+      const gatewayBaseUrl = this.baseUrl.replace(/\/v1\/api\/?$/, "");
+      await tryRequest(`${labelPrefix} POST /v1/portal/iserver/reauthenticate?force=true`, () =>
+        client.post(`${gatewayBaseUrl}/v1/portal/iserver/reauthenticate?force=true`)
+      );
+      await sleep(1000);
       await tryRequest(`${labelPrefix} POST /v1/api/iserver/reauthenticate`, () => client.post("/iserver/reauthenticate"));
       await sleep(1000);
       await tryRequest(`${labelPrefix} POST /v1/api/tickle`, () => client.post("/tickle"));

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -149,11 +149,12 @@ export class ToolHandlers {
 
       // Throw a standard Error that formatError knows how to parse or that is easy to check
       const payload = {
-        status: "AWAITING_AUTHENTICATION",
-        message: `Headless login has been started in the background. IBKR may ask for mobile approval, a security code, or second-factor method selection. Complete the visible IBKR authentication step at ${authUrl}, then re-run this command.`,
+        status: "AUTHENTICATION_STARTED",
+        message: `Headless login has been started in the background, but no 2FA challenge has been verified yet. Re-run this command after the login completes, or open ${authUrl} to inspect the current IBKR authentication screen.`,
         url: authUrl,
         requiresAction: true,
         authStarted: true,
+        twoFactorPending: false,
         notificationVerified: false
       };
       

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -137,7 +137,9 @@ export class ToolHandlers {
       const p = authenticator.authenticate(authConfig);
       if (p && typeof p.then === "function") {
         p.then(async (result) => {
-          await authenticator.close().catch(() => {});
+          if (!result.browserKeptOpen) {
+            await authenticator.close().catch(() => {});
+          }
           Logger.info(`🎯 Background headless authentication completed: success=${result.success}`);
         }).catch(async (err) => {
           await authenticator.close().catch(() => {});
@@ -148,9 +150,11 @@ export class ToolHandlers {
       // Throw a standard Error that formatError knows how to parse or that is easy to check
       const payload = {
         status: "AWAITING_AUTHENTICATION",
-        message: `Authentication has been automatically triggered in the background. Please check your mobile device for the IB Key 2FA push notification or log in manually at ${authUrl} to authenticate. Once completed, re-run this command.`,
+        message: `Headless login has been started in the background. IBKR may ask for mobile approval, a security code, or second-factor method selection. Complete the visible IBKR authentication step at ${authUrl}, then re-run this command.`,
         url: authUrl,
-        requiresAction: true
+        requiresAction: true,
+        authStarted: true,
+        notificationVerified: false
       };
       
       return {
@@ -323,8 +327,11 @@ export class ToolHandlers {
           const authenticator = new HeadlessAuthenticator();
           const result = await authenticator.authenticate(authConfig);
 
-          // Authentication completed (success or failure) - no separate 2FA handling needed
-          await authenticator.close();
+          // Keep the browser alive only when the authenticator reports a user-action
+          // 2FA state that can still be completed after this tool response.
+          if (!result.browserKeptOpen) {
+            await authenticator.close();
+          }
           
           return {
             content: [

--- a/test/gateway-manager.test.ts
+++ b/test/gateway-manager.test.ts
@@ -97,12 +97,18 @@ describe('IBGatewayManager runtime platform resolution', () => {
 
 describe('IBGatewayManager existing gateway selection', () => {
   const originalForceStandalone = process.env.IB_FORCE_STANDALONE_GATEWAY;
+  const originalGatewayPort = process.env.IB_GATEWAY_PORT;
 
   afterEach(() => {
     if (originalForceStandalone === undefined) {
       delete process.env.IB_FORCE_STANDALONE_GATEWAY;
     } else {
       process.env.IB_FORCE_STANDALONE_GATEWAY = originalForceStandalone;
+    }
+    if (originalGatewayPort === undefined) {
+      delete process.env.IB_GATEWAY_PORT;
+    } else {
+      process.env.IB_GATEWAY_PORT = originalGatewayPort;
     }
     vi.restoreAllMocks();
   });
@@ -146,5 +152,35 @@ describe('IBGatewayManager existing gateway selection', () => {
 
     expect(port).toBe(5000);
     expect(checkGatewayHealthSpy).toHaveBeenCalledWith(5000);
+  });
+
+  it('reuses a reachable configured port before process-name discovery', async () => {
+    process.env.IB_FORCE_STANDALONE_GATEWAY = 'false';
+    process.env.IB_GATEWAY_PORT = '5002';
+    const findExistingGatewaySpy = vi.spyOn(PortUtils, 'findExistingGateway').mockResolvedValue(null);
+    const manager = new IBGatewayManager() as unknown as {
+      quickCheckExistingGateway: () => Promise<number | null>;
+      checkGatewayHealth: (port?: number) => Promise<boolean>;
+    };
+    const checkGatewayHealthSpy = vi
+      .spyOn(manager, 'checkGatewayHealth')
+      .mockImplementation(async (port?: number) => port === 5002);
+
+    const port = await manager.quickCheckExistingGateway();
+
+    expect(port).toBe(5002);
+    expect(checkGatewayHealthSpy).toHaveBeenCalledWith(5002);
+    expect(findExistingGatewaySpy).not.toHaveBeenCalled();
+  });
+
+  it('treats unauthenticated API responses as a live Gateway health signal', () => {
+    const manager = new IBGatewayManager() as unknown as {
+      isLiveGatewayResponse: (pathname: string, statusCode?: number) => boolean;
+    };
+
+    expect(manager.isLiveGatewayResponse('/v1/api/iserver/auth/status', 401)).toBe(true);
+    expect(manager.isLiveGatewayResponse('/v1/api/iserver/auth/status', 403)).toBe(true);
+    expect(manager.isLiveGatewayResponse('/v1/api/iserver/auth/status', 404)).toBe(false);
+    expect(manager.isLiveGatewayResponse('/', 404)).toBe(false);
   });
 });

--- a/test/headless-auth.test.ts
+++ b/test/headless-auth.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HeadlessAuthenticator } from '../src/headless-auth.js';
+
+describe('HeadlessAuthenticator state detection', () => {
+  it('marks security-code 2FA as waiting for user action without claiming push delivery', async () => {
+    const authenticator = new HeadlessAuthenticator() as any;
+    authenticator.page = {
+      evaluate: vi.fn().mockResolvedValue({
+        visibleText: 'Enter temporary security code',
+        visibleButtons: 'Submit',
+      }),
+    };
+
+    const state = await authenticator.detectTwoFactorState();
+    const result = authenticator.buildWaitingFor2FAResult(state, 60_000);
+
+    expect(state).toMatchObject({
+      detected: true,
+      method: 'security_code',
+    });
+    expect(result).toMatchObject({
+      success: false,
+      status: 'WAITING_FOR_USER_2FA',
+      waitingFor2FA: true,
+      pushDelivered: false,
+      browserKeptOpen: true,
+    });
+  });
+
+  it('only marks push delivery when the page explicitly says a notification was sent', async () => {
+    const authenticator = new HeadlessAuthenticator() as any;
+    authenticator.page = {
+      evaluate: vi.fn().mockResolvedValue({
+        visibleText: 'We sent you a notification. Open the IBKR notification to continue.',
+        visibleButtons: 'Resend notification',
+      }),
+    };
+
+    const state = await authenticator.detectTwoFactorState();
+    const result = authenticator.buildWaitingFor2FAResult(state, 60_000);
+
+    expect(state).toMatchObject({
+      detected: true,
+      method: 'ibkr_mobile_push',
+    });
+    expect(result.pushDelivered).toBe(true);
+  });
+
+  it('detects credential/authentication failures separately from 2FA waits', async () => {
+    const authenticator = new HeadlessAuthenticator() as any;
+    authenticator.page = {
+      evaluate: vi.fn().mockResolvedValue({
+        visibleText: 'Login failed. Invalid username or password.',
+        visibleAlerts: 'Invalid username or password.',
+      }),
+    };
+
+    const state = await authenticator.detectAuthenticationFailureState();
+
+    expect(state).toMatchObject({
+      detected: true,
+    });
+    expect(state.message).toContain('invalid username');
+  });
+});

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -28,7 +28,7 @@ describe('IBClient', () => {
     
     vi.mocked(axios.create).mockReturnValue(mockAxiosInstance as any);
     
-    client = new IBClient(mockConfig);
+    client = new IBClient({ ...mockConfig });
   });
 
   afterEach(() => {
@@ -622,6 +622,9 @@ describe('IBClient', () => {
         expect.stringContaining('machineId=71a482fc'),
         expect.any(Object)
       );
+      expect(mockAuthClient.post).toHaveBeenCalledWith(
+        'https://localhost:5000/v1/portal/iserver/reauthenticate?force=true'
+      );
       expect(mockAuthClient.post).toHaveBeenCalledWith('/iserver/reauthenticate');
       expect(mockAuthClient.post).toHaveBeenCalledWith('/tickle');
     });
@@ -758,4 +761,3 @@ describe('IBClient', () => {
     });
   });
 });
-

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -346,10 +346,11 @@ describe('ToolHandlers', () => {
 
       expect(result.content).toBeDefined();
       const payload = JSON.parse(result.content[0].text);
-      expect(payload.status).toBe('AWAITING_AUTHENTICATION');
+      expect(payload.status).toBe('AUTHENTICATION_STARTED');
       expect(payload.requiresAction).toBe(true);
       expect(payload.url).toContain('5000');
       expect(payload.authStarted).toBe(true);
+      expect(payload.twoFactorPending).toBe(false);
       expect(payload.notificationVerified).toBe(false);
       expect(payload.message).not.toContain('push notification');
     });

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -345,11 +345,13 @@ describe('ToolHandlers', () => {
       const result = await handlers.getAccountInfo({ confirm: true });
 
       expect(result.content).toBeDefined();
-      console.log('RESULT TEXT:', result.content[0].text);
       const payload = JSON.parse(result.content[0].text);
       expect(payload.status).toBe('AWAITING_AUTHENTICATION');
       expect(payload.requiresAction).toBe(true);
       expect(payload.url).toContain('5000');
+      expect(payload.authStarted).toBe(true);
+      expect(payload.notificationVerified).toBe(false);
+      expect(payload.message).not.toContain('push notification');
     });
   });
 
@@ -823,4 +825,3 @@ describe('ToolHandlers', () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary
- reuse a live Client Portal Gateway via HTTP-first probes, treating unauthenticated 401/403 API responses as alive
- detach spawned Gateway process so MCP host SIGTERM does not unnecessarily tear down the Java gateway
- make headless auth state reporting honest: distinguish user 2FA waits, credential failures, timeouts, and verified push delivery
- update IBKR login selectors for current xyz-field username/password DOM and extend default auth timeout to 5 minutes

## Verification
- npm run build
- npm test

## Manual follow-up
- Verify against live IBKR that an already-running unauthenticated gateway is reused
- Verify real 2FA approval transitions Client Portal REST auth to authenticated/established