### PR TITLE
Make Gateway startup durable

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,20 @@ For a complete guide on creating and customizing Flex Queries, see the [IB Flex 
 | Flex Token | `IB_FLEX_TOKEN` | N/A |
 | Read-only mode | `IB_READ_ONLY_MODE` | `--ib-read-only-mode` |
 
+## Gateway Lifecycle
+
+On startup, the MCP first probes reachable local Gateway endpoints on the configured port and common Client Portal Gateway ports. If a healthy existing Gateway is found, the MCP attaches to it and does not start another bundled Gateway.
+
+When no suitable existing Gateway is reachable, the MCP starts the bundled Java Gateway as a durable detached process. Runtime coordination files are stored under `ib-gateway/.runtime/`:
+
+- `gateway-session.json` records the MCP-managed Gateway pid, port, version, and log paths.
+- `gateway-session.lock` prevents two MCP processes from starting duplicate managed Gateways at the same time.
+- `gateway.stdout.log` and `gateway.stderr.log` receive the Gateway process output.
+
+Normal MCP shutdown detaches from the Gateway and leaves it running so later MCP runs can reuse it. If `IB_FORCE_STANDALONE_GATEWAY=true` is set, the MCP skips unrelated external Gateway discovery, but it still reuses or coordinates through the durable MCP-managed session metadata and lock files.
+
+To reset the managed Gateway session, stop the Gateway process recorded in `ib-gateway/.runtime/gateway-session.json`, then remove `ib-gateway/.runtime/gateway-session.json` and any stale `ib-gateway/.runtime/gateway-session.lock`. The MCP automatically removes stale metadata when the recorded pid no longer exists.
+
 ## Available MCP Tools
 
 ### Trading & Account Management
@@ -222,6 +236,8 @@ For a complete guide on creating and customizing Flex Queries, see the [IB Flex 
 
 - If another IB Gateway is already listening on a local port but should not be reused, set `IB_FORCE_STANDALONE_GATEWAY=true`
 - Existing gateways are only reused when the MCP process can reach them over HTTPS; otherwise the bundled standalone gateway is started on an available port
+- For MCP-managed Gateway startup issues, inspect `ib-gateway/.runtime/gateway.stdout.log`, `ib-gateway/.runtime/gateway.stderr.log`, and `ib-gateway/.runtime/gateway-session.json`
+- To clear a stale managed startup lock, confirm no MCP process is currently starting Gateway, then remove `ib-gateway/.runtime/gateway-session.lock`
 
 ## Support
 

--- a/ib-gateway/.gitignore
+++ b/ib-gateway/.gitignore
@@ -23,3 +23,4 @@ vertx/**/*
 .vertx/
 **/.vertx/
 *.vertx
+

--- a/ib-gateway/.gitignore
+++ b/ib-gateway/.gitignore
@@ -6,6 +6,7 @@
 
 # But still ignore logs and temporary files
 logs/
+.runtime/
 *.log
 *.tmp
 *.temp

--- a/src/gateway-manager.ts
+++ b/src/gateway-manager.ts
@@ -1,5 +1,6 @@
 import { spawn, ChildProcess } from 'child_process';
 import { promises as fs, existsSync as fsExistsSync } from 'fs';
+import type { FileHandle } from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
@@ -17,10 +18,26 @@ const MUSL_RUNTIME_DOWNLOADS: Record<string, string> = {
   'linux-arm64-musl': 'https://download.bell-sw.com/java/11.0.31+11/bellsoft-jre11.0.31+11-linux-aarch64-musl.tar.gz',
 };
 
+type GatewaySessionMetadata = {
+  managedBy: 'interactive-brokers-mcp';
+  version: string;
+  pid: number;
+  port: number;
+  startedAt: string;
+  gatewayDir: string;
+  stdoutLog: string;
+  stderrLog: string;
+};
+
 export class IBGatewayManager {
   private gatewayProcess: ChildProcess | null = null;
   private gatewayDir: string;
   private jreDir: string;
+  private runtimeDir: string;
+  private metadataPath: string;
+  private lockPath: string;
+  private stdoutLogPath: string;
+  private stderrLogPath: string;
   private isStarting = false;
   private isReady = false;
   private useStderr: boolean;
@@ -41,6 +58,11 @@ export class IBGatewayManager {
   constructor() {
     this.gatewayDir = path.join(__dirname, '../ib-gateway');
     this.jreDir = path.join(__dirname, '../runtime');
+    this.runtimeDir = path.join(this.gatewayDir, '.runtime');
+    this.metadataPath = path.join(this.runtimeDir, 'gateway-session.json');
+    this.lockPath = path.join(this.runtimeDir, 'gateway-session.lock');
+    this.stdoutLogPath = path.join(this.runtimeDir, 'gateway.stdout.log');
+    this.stderrLogPath = path.join(this.runtimeDir, 'gateway.stderr.log');
     this.useStderr = !(process.env.MCP_HTTP_SERVER === 'true' || process.argv.includes('--http'));
     this.forceStandaloneGateway = process.env.IB_FORCE_STANDALONE_GATEWAY === 'true';
     this.registerCleanupHandlers();
@@ -80,8 +102,8 @@ export class IBGatewayManager {
 
   private async findExistingGateway(): Promise<number | null> {
     if (this.forceStandaloneGateway) {
-      this.log('Standalone gateway mode enabled; skipping existing gateway discovery');
-      return null;
+      this.log('Standalone gateway mode enabled; checking only MCP-managed Gateway session');
+      return this.findManagedGateway();
     }
     this.log('🔍 Checking for existing Gateway instances...');
 
@@ -109,8 +131,8 @@ export class IBGatewayManager {
 
   async quickCheckExistingGateway(): Promise<number | null> {
     if (this.forceStandaloneGateway) {
-      this.log('Standalone gateway mode enabled; skipping quick existing gateway discovery');
-      return null;
+      this.log('Standalone gateway mode enabled; checking only MCP-managed Gateway session');
+      return this.findManagedGateway();
     }
     this.log('⚡ Quick check for existing Gateway instances...');
     try {
@@ -346,6 +368,153 @@ export class IBGatewayManager {
     }
   }
 
+  private async ensureRuntimeDir(): Promise<void> {
+    await fs.mkdir(this.runtimeDir, { recursive: true });
+  }
+
+  private isProcessAlive(pid: number): boolean {
+    if (!Number.isInteger(pid) || pid <= 0) {
+      return false;
+    }
+
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      return code === 'EPERM';
+    }
+  }
+
+  private async readManagedSessionMetadata(): Promise<GatewaySessionMetadata | null> {
+    try {
+      const rawMetadata = await fs.readFile(this.metadataPath, 'utf8');
+      const metadata = JSON.parse(rawMetadata) as Partial<GatewaySessionMetadata>;
+      if (
+        metadata.managedBy !== 'interactive-brokers-mcp' ||
+        !Number.isInteger(metadata.pid) ||
+        !Number.isInteger(metadata.port)
+      ) {
+        return null;
+      }
+
+      return metadata as GatewaySessionMetadata;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        this.log(`Ignoring unreadable managed Gateway metadata: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      return null;
+    }
+  }
+
+  private async writeManagedSessionMetadata(pid: number, port: number): Promise<void> {
+    await this.ensureRuntimeDir();
+    const metadata: GatewaySessionMetadata = {
+      managedBy: 'interactive-brokers-mcp',
+      version: packageJson.version,
+      pid,
+      port,
+      startedAt: new Date().toISOString(),
+      gatewayDir: this.gatewayDir,
+      stdoutLog: this.stdoutLogPath,
+      stderrLog: this.stderrLogPath,
+    };
+
+    await fs.writeFile(this.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf8');
+  }
+
+  private async clearManagedSessionMetadata(): Promise<void> {
+    await fs.rm(this.metadataPath, { force: true }).catch(() => undefined);
+  }
+
+  private async findManagedGateway(): Promise<number | null> {
+    const metadata = await this.readManagedSessionMetadata();
+    if (!metadata) {
+      return null;
+    }
+
+    if (!this.isProcessAlive(metadata.pid)) {
+      this.log(`Removing stale managed Gateway metadata for pid ${metadata.pid}`);
+      await this.clearManagedSessionMetadata();
+      return null;
+    }
+
+    const isReachable = await this.checkGatewayHealth(metadata.port);
+    if (!isReachable) {
+      this.log(`Managed Gateway pid ${metadata.pid} exists but port ${metadata.port} is not reachable yet`);
+      return null;
+    }
+
+    this.log(`✅ Found MCP-managed Gateway pid ${metadata.pid} on port ${metadata.port}`);
+    return metadata.port;
+  }
+
+  private async acquireManagedGatewayLock(): Promise<FileHandle> {
+    await this.ensureRuntimeDir();
+
+    try {
+      const handle = await fs.open(this.lockPath, 'wx');
+      await handle.writeFile(JSON.stringify({
+        pid: process.pid,
+        createdAt: new Date().toISOString(),
+      }));
+      return handle;
+    } catch (error) {
+      const errno = (error as NodeJS.ErrnoException).code;
+      if (errno !== 'EEXIST') {
+        throw error;
+      }
+
+      const lockOwnerPid = await this.readLockOwnerPid();
+      if (lockOwnerPid && this.isProcessAlive(lockOwnerPid)) {
+        throw new Error(`Another MCP process is starting the managed Gateway (lock held by pid ${lockOwnerPid})`);
+      }
+
+      this.log('Removing stale managed Gateway startup lock');
+      await fs.rm(this.lockPath, { force: true });
+      const handle = await fs.open(this.lockPath, 'wx');
+      await handle.writeFile(JSON.stringify({
+        pid: process.pid,
+        createdAt: new Date().toISOString(),
+      }));
+      return handle;
+    }
+  }
+
+  private async readLockOwnerPid(): Promise<number | null> {
+    try {
+      const rawLock = await fs.readFile(this.lockPath, 'utf8');
+      const lock = JSON.parse(rawLock) as { pid?: unknown };
+      return typeof lock.pid === 'number' && Number.isInteger(lock.pid) ? lock.pid : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async releaseManagedGatewayLock(handle: FileHandle | null): Promise<void> {
+    if (!handle) {
+      return;
+    }
+
+    await handle.close().catch(() => undefined);
+    await fs.rm(this.lockPath, { force: true }).catch(() => undefined);
+  }
+
+  private async waitForManagedGatewayFromMetadata(): Promise<boolean> {
+    const maxAttempts = 30;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const managedPort = await this.findManagedGateway();
+      if (managedPort) {
+        this.currentPort = managedPort;
+        this.isReady = true;
+        return true;
+      }
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+
+    return false;
+  }
+
   // Public method for fast initialization (used during server startup)
   async quickStartGateway(): Promise<void> {
     this.log('⚡ Quick Gateway initialization...');
@@ -385,7 +554,7 @@ export class IBGatewayManager {
     })();
     
     // Add unhandled rejection handler to prevent process termination
-    this.backgroundStartupPromise.catch((error) => {
+    this.backgroundStartupPromise.catch(() => {
       // Error already logged above, just prevent unhandled rejection
     });
   }
@@ -437,10 +606,35 @@ export class IBGatewayManager {
       return;
     }
 
+    let lockHandle: FileHandle | null = null;
     this.isStarting = true;
     this.spawnFailure = null;
 
     try {
+      const managedPort = await this.findManagedGateway();
+      if (managedPort) {
+        this.currentPort = managedPort;
+        this.isReady = true;
+        return;
+      }
+
+      try {
+        lockHandle = await this.acquireManagedGatewayLock();
+      } catch (error) {
+        this.log(`Managed Gateway startup lock is held: ${error instanceof Error ? error.message : String(error)}`);
+        if (await this.waitForManagedGatewayFromMetadata()) {
+          return;
+        }
+        throw error;
+      }
+
+      const managedPortAfterLock = await this.findManagedGateway();
+      if (managedPortAfterLock) {
+        this.currentPort = managedPortAfterLock;
+        this.isReady = true;
+        return;
+      }
+
       await this.ensureGatewayExists();
       
       // Check port availability for new Gateway
@@ -460,7 +654,7 @@ export class IBGatewayManager {
           await ConfigUtils.createTempConfigWithPort(this.gatewayDir, this.currentPort);
           this.log(`📝 Created temporary config file with port ${this.currentPort}`);
         } catch (error) {
-          this.log(`❌ No alternative ports available, will try with default port anyway`);
+          this.log('❌ No alternative ports available, will try with default port anyway');
           this.currentPort = defaultPort;
         }
       }
@@ -480,11 +674,17 @@ export class IBGatewayManager {
       this.log('🚀 Starting IB Gateway with bundled JRE...');
       this.log('   Java: ' + bundledJavaPath);
       this.log('   Java Home: ' + bundledJavaHome);
-      this.log('   Lib Path: ' + `${bundledJavaServerLibPath}:${bundledJavaLibPath}`);
+      this.log(`   Lib Path: ${bundledJavaServerLibPath}:${bundledJavaLibPath}`);
       this.log('   Config: ' + configFile);
       this.log('   Port: ' + this.currentPort);
       
-      this.gatewayProcess = spawn(bundledJavaPath, [
+      await this.ensureRuntimeDir();
+      const stdoutHandle = await fs.open(this.stdoutLogPath, 'a');
+      const stderrHandle = await fs.open(this.stderrLogPath, 'a');
+      await stdoutHandle.write(`\n[${new Date().toISOString()}] Starting IB Gateway on port ${this.currentPort}\n`);
+      await stderrHandle.write(`\n[${new Date().toISOString()}] Starting IB Gateway on port ${this.currentPort}\n`);
+
+      const gatewayProcess = spawn(bundledJavaPath, [
         '-server',
         '-Djava.awt.headless=true',
         '-Xmx512m',
@@ -505,37 +705,15 @@ export class IBGatewayManager {
           JAVA_HOME: bundledJavaHome,
           LD_LIBRARY_PATH: `${bundledJavaServerLibPath}:${bundledJavaLibPath}:${process.env.LD_LIBRARY_PATH || ''}`
         },
-        stdio: ['ignore', 'pipe', 'pipe']
+        stdio: ['ignore', stdoutHandle.fd, stderrHandle.fd]
       });
 
-      this.gatewayProcess.unref();
+      this.gatewayProcess = gatewayProcess;
+      gatewayProcess.unref();
+      await stdoutHandle.close();
+      await stderrHandle.close();
 
-      // Buffer the tail of stderr so we can include it in a failure reason if the process
-      // dies before the gateway's HTTP port comes up.
-      let stderrTail = '';
-
-      this.gatewayProcess.stdout?.on('data', (data) => {
-        const output = data.toString().trim();
-        if (output) {
-          this.log(`[Gateway] ${output}`);
-          // Check for startup completion indicators
-          if (output.includes('Server ready') || output.includes('started on port')) {
-            this.isReady = true;
-            this.log('✅ IB Gateway is ready!');
-          }
-        }
-      });
-
-      this.gatewayProcess.stderr?.on('data', (data) => {
-        const chunk = data.toString();
-        stderrTail = (stderrTail + chunk).slice(-IBGatewayManager.STDERR_TAIL_BYTES);
-        const trimmed = chunk.trim();
-        if (trimmed && !trimmed.includes('WARNING')) {
-          Logger.error(`[Gateway Error] ${trimmed}`);
-        }
-      });
-
-      this.gatewayProcess.on('error', (error) => {
+      gatewayProcess.once('error', (error) => {
         Logger.error('❌ Gateway process error:', error.message);
         this.spawnFailure = {
           reason: this.diagnoseSpawnError(error, bundledJavaPath),
@@ -545,24 +723,9 @@ export class IBGatewayManager {
         this.isReady = false;
       });
 
-      this.gatewayProcess.on('exit', (code, signal) => {
-        this.log(`🛑 Gateway process exited with code ${code}, signal ${signal}`);
-        // Any exit before the gateway became ready is a failure: a clean exit-0 means the JVM
-        // terminated without ever opening the HTTP port (e.g. config error), and code===null
-        // means the process was killed by a signal (e.g. OOM). Recording spawnFailure for all
-        // of these makes waitForGateway() bail out fast instead of polling for 30s.
-        if (!this.isReady && !this.spawnFailure) {
-          const exitDescriptor =
-            code !== null ? `code ${code}` : `signal ${signal ?? 'unknown'}`;
-          this.spawnFailure = {
-            reason: `IB Gateway process exited (${exitDescriptor}) before becoming ready`,
-            details: stderrTail.trim() || `(no stderr captured)`,
-          };
-        }
-        this.gatewayProcess = null;
-        this.isStarting = false;
-        this.isReady = false;
-      });
+      if (gatewayProcess.pid) {
+        await this.writeManagedSessionMetadata(gatewayProcess.pid, this.currentPort);
+      }
 
       // Wait for the gateway to be ready
       this.log('⏳ Waiting for IB Gateway to start...');
@@ -576,6 +739,8 @@ export class IBGatewayManager {
       this.isStarting = false;
       this.isReady = false;
       throw error;
+    } finally {
+      await this.releaseManagedGatewayLock(lockHandle);
     }
   }
 
@@ -596,7 +761,7 @@ export class IBGatewayManager {
           this.log(`✅ IB Gateway is responding on port ${this.currentPort}`);
           return;
         }
-      } catch (error) {
+      } catch {
         // Gateway not ready yet, continue waiting
       }
 
@@ -611,7 +776,7 @@ export class IBGatewayManager {
     if (this.spawnFailure) {
       throw this.buildSpawnFailureError();
     }
-    throw new Error('IB Gateway failed to start within 30 seconds');
+    throw new Error(`IB Gateway failed to start within 30 seconds. See logs at ${this.stdoutLogPath} and ${this.stderrLogPath}`);
   }
 
   private buildSpawnFailureError(): Error {

--- a/test/gateway-manager.test.ts
+++ b/test/gateway-manager.test.ts
@@ -1,8 +1,18 @@
 // test/gateway-manager.test.ts
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
 import * as fs from 'fs';
+import { spawn } from 'child_process';
 import { IBGatewayManager } from '../src/gateway-manager.js';
 import { PortUtils } from '../src/utils/port-utils.js';
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    spawn: vi.fn(actual.spawn),
+  };
+});
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof fs>('fs');
@@ -116,11 +126,30 @@ describe('IBGatewayManager existing gateway selection', () => {
   it('skips existing gateway discovery when standalone mode is forced', async () => {
     process.env.IB_FORCE_STANDALONE_GATEWAY = 'true';
     const findExistingGatewaySpy = vi.spyOn(PortUtils, 'findExistingGateway');
-    const manager = new IBGatewayManager();
+    const manager = new IBGatewayManager() as unknown as {
+      quickCheckExistingGateway: () => Promise<number | null>;
+      findManagedGateway: () => Promise<number | null>;
+    };
+    vi.spyOn(manager, 'findManagedGateway').mockResolvedValue(null);
 
     const port = await manager.quickCheckExistingGateway();
 
     expect(port).toBeNull();
+    expect(findExistingGatewaySpy).not.toHaveBeenCalled();
+  });
+
+  it('still reuses an MCP-managed gateway when standalone mode is forced', async () => {
+    process.env.IB_FORCE_STANDALONE_GATEWAY = 'true';
+    const findExistingGatewaySpy = vi.spyOn(PortUtils, 'findExistingGateway');
+    const manager = new IBGatewayManager() as unknown as {
+      quickCheckExistingGateway: () => Promise<number | null>;
+      findManagedGateway: () => Promise<number | null>;
+    };
+    vi.spyOn(manager, 'findManagedGateway').mockResolvedValue(5003);
+
+    const port = await manager.quickCheckExistingGateway();
+
+    expect(port).toBe(5003);
     expect(findExistingGatewaySpy).not.toHaveBeenCalled();
   });
 
@@ -182,5 +211,153 @@ describe('IBGatewayManager existing gateway selection', () => {
     expect(manager.isLiveGatewayResponse('/v1/api/iserver/auth/status', 403)).toBe(true);
     expect(manager.isLiveGatewayResponse('/v1/api/iserver/auth/status', 404)).toBe(false);
     expect(manager.isLiveGatewayResponse('/', 404)).toBe(false);
+  });
+});
+
+describe('IBGatewayManager durable managed sessions', () => {
+  const originalForceStandalone = process.env.IB_FORCE_STANDALONE_GATEWAY;
+  const originalGatewayPort = process.env.IB_GATEWAY_PORT;
+
+  afterEach(() => {
+    if (originalForceStandalone === undefined) {
+      delete process.env.IB_FORCE_STANDALONE_GATEWAY;
+    } else {
+      process.env.IB_FORCE_STANDALONE_GATEWAY = originalForceStandalone;
+    }
+    if (originalGatewayPort === undefined) {
+      delete process.env.IB_GATEWAY_PORT;
+    } else {
+      process.env.IB_GATEWAY_PORT = originalGatewayPort;
+    }
+    vi.restoreAllMocks();
+    vi.mocked(spawn).mockReset();
+  });
+
+  function createMockGatewayProcess(pid = 4321) {
+    const gatewayProcess = new EventEmitter() as EventEmitter & {
+      pid: number;
+      unref: ReturnType<typeof vi.fn>;
+    };
+    gatewayProcess.pid = pid;
+    gatewayProcess.unref = vi.fn();
+    return gatewayProcess;
+  }
+
+  function mockManagedStartup(manager: IBGatewayManager, pid = 4321) {
+    const privateManager = manager as unknown as {
+      ensureGatewayExists: () => Promise<void>;
+      getJavaPath: () => Promise<string>;
+      checkGatewayHealth: (port?: number) => Promise<boolean>;
+      acquireManagedGatewayLock: () => Promise<{ close: () => Promise<void> }>;
+      releaseManagedGatewayLock: (handle: { close: () => Promise<void> } | null) => Promise<void>;
+      writeManagedSessionMetadata: (processId: number, port: number) => Promise<void>;
+      ensureRuntimeDir: () => Promise<void>;
+      startGatewayInternal: () => Promise<void>;
+    };
+    const lockHandle = { close: vi.fn().mockResolvedValue(undefined) };
+    vi.spyOn(privateManager, 'ensureGatewayExists').mockResolvedValue(undefined);
+    vi.spyOn(privateManager, 'getJavaPath').mockResolvedValue('/runtime/linux-x64/bin/java');
+    vi.spyOn(privateManager, 'checkGatewayHealth').mockResolvedValue(true);
+    vi.spyOn(privateManager, 'acquireManagedGatewayLock').mockResolvedValue(lockHandle);
+    vi.spyOn(privateManager, 'releaseManagedGatewayLock').mockResolvedValue(undefined);
+    vi.spyOn(privateManager, 'writeManagedSessionMetadata').mockResolvedValue(undefined);
+    vi.spyOn(privateManager, 'ensureRuntimeDir').mockResolvedValue(undefined);
+    vi.spyOn(PortUtils, 'isPortAvailable').mockResolvedValue(true);
+    vi.mocked(spawn).mockReturnValue(createMockGatewayProcess(pid) as never);
+
+    return { privateManager, lockHandle };
+  }
+
+  it('spawns the bundled Gateway detached with durable file stdio and writes metadata', async () => {
+    const manager = new IBGatewayManager();
+    const { privateManager } = mockManagedStartup(manager, 9876);
+    const openSpy = vi.spyOn(fs.promises, 'open')
+      .mockResolvedValueOnce({ fd: 31, write: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined) } as never)
+      .mockResolvedValueOnce({ fd: 32, write: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined) } as never);
+    const metadataSpy = vi.spyOn(privateManager, 'writeManagedSessionMetadata');
+
+    await privateManager.startGatewayInternal();
+
+    expect(openSpy).toHaveBeenCalledWith(expect.stringContaining('gateway.stdout.log'), 'a');
+    expect(openSpy).toHaveBeenCalledWith(expect.stringContaining('gateway.stderr.log'), 'a');
+    expect(spawn).toHaveBeenCalledWith(
+      '/runtime/linux-x64/bin/java',
+      expect.any(Array),
+      expect.objectContaining({
+        detached: true,
+        stdio: ['ignore', 31, 32],
+      }),
+    );
+    const spawnedProcess = vi.mocked(spawn).mock.results[0]?.value as ReturnType<typeof createMockGatewayProcess>;
+    expect(spawnedProcess.unref).toHaveBeenCalled();
+    expect(metadataSpy).toHaveBeenCalledWith(9876, 5000);
+  });
+
+  it('cleans up stale managed metadata when the stored pid is gone', async () => {
+    const manager = new IBGatewayManager() as unknown as {
+      findManagedGateway: () => Promise<number | null>;
+      readManagedSessionMetadata: () => Promise<{ managedBy: string; pid: number; port: number } | null>;
+      clearManagedSessionMetadata: () => Promise<void>;
+      isProcessAlive: (pid: number) => boolean;
+    };
+    vi.spyOn(manager, 'readManagedSessionMetadata').mockResolvedValue({
+      managedBy: 'interactive-brokers-mcp',
+      pid: 99999,
+      port: 5004,
+    });
+    vi.spyOn(manager, 'isProcessAlive').mockReturnValue(false);
+    const clearSpy = vi.spyOn(manager, 'clearManagedSessionMetadata').mockResolvedValue(undefined);
+
+    await expect(manager.findManagedGateway()).resolves.toBeNull();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  it('prevents a second managed start while another live process owns the lock', async () => {
+    const manager = new IBGatewayManager() as unknown as {
+      startGatewayInternal: () => Promise<void>;
+      findManagedGateway: () => Promise<number | null>;
+      acquireManagedGatewayLock: () => Promise<never>;
+      waitForManagedGatewayFromMetadata: () => Promise<boolean>;
+    };
+    vi.spyOn(manager, 'findManagedGateway').mockResolvedValue(null);
+    vi.spyOn(manager, 'acquireManagedGatewayLock').mockRejectedValue(new Error('Another MCP process is starting the managed Gateway (lock held by pid 1234)'));
+    vi.spyOn(manager, 'waitForManagedGatewayFromMetadata').mockResolvedValue(false);
+
+    await expect(manager.startGatewayInternal()).rejects.toThrow('lock held by pid 1234');
+  });
+
+  it('detaches on shutdown without killing the durable Gateway process', async () => {
+    const manager = new IBGatewayManager() as unknown as {
+      gatewayProcess: { kill: ReturnType<typeof vi.fn> } | null;
+      isReady: boolean;
+      stopGateway: () => Promise<void>;
+    };
+    const kill = vi.fn();
+    manager.gatewayProcess = { kill };
+    manager.isReady = true;
+
+    await manager.stopGateway();
+
+    expect(kill).not.toHaveBeenCalled();
+    expect(manager.gatewayProcess).toBeNull();
+    expect(manager.isReady).toBe(false);
+  });
+
+  it('waits for the managed session instead of spawning when the startup lock is held', async () => {
+    const manager = new IBGatewayManager() as unknown as {
+      startGatewayInternal: () => Promise<void>;
+      findManagedGateway: () => Promise<number | null>;
+      acquireManagedGatewayLock: () => Promise<never>;
+      waitForManagedGatewayFromMetadata: () => Promise<boolean>;
+      ensureGatewayExists: () => Promise<void>;
+    };
+    vi.spyOn(manager, 'findManagedGateway').mockResolvedValue(null);
+    vi.spyOn(manager, 'acquireManagedGatewayLock').mockRejectedValue(new Error('lock held'));
+    vi.spyOn(manager, 'waitForManagedGatewayFromMetadata').mockResolvedValue(true);
+    const ensureGatewayExistsSpy = vi.spyOn(manager, 'ensureGatewayExists').mockResolvedValue(undefined);
+
+    await manager.startGatewayInternal();
+
+    expect(ensureGatewayExistsSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add durable MCP-managed Gateway session metadata, startup lock, and stdout/stderr log files under ib-gateway/.runtime
- preserve healthy existing Gateway attachment before bundled startup, while force-standalone reuses only MCP-managed sessions
- detach on MCP shutdown without killing Gateway and document reset/debug steps

## Verification
- npm test
- npm run build
- npm run lint
- git diff --check

Note: pnpm is not installed in this environment, and this repo currently has no format script.