### PR TITLE
Improve pending IBKR auth wait UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ credentials without opening a browser window. This is useful for:
 
 **Important**: Even in headless mode, Interactive Brokers may still require
 two-factor authentication (2FA). When 2FA is triggered, the headless
-authentication will wait for you to complete the 2FA process through your
-configured method (mobile app, SMS, etc.) before proceeding.
+authentication will wait up to 60 seconds for you to complete the 2FA process
+through your configured method (mobile app, SMS, etc.) before returning an
+`AUTHENTICATION_PENDING` response. Wait for approval to complete, then check
+account info again.
 
 To enable paper trading, add `"IB_PAPER_TRADING": "true"` to your environment variables:
 
@@ -185,6 +187,8 @@ For a complete guide on creating and customizing Flex Queries, see the [IB Flex 
 | Headless Mode | `IB_HEADLESS_MODE` | `--ib-headless-mode` |
 | Paper Trading | `IB_PAPER_TRADING` | `--ib-paper-trading` |
 | Auth Timeout | `IB_AUTH_TIMEOUT` | `--ib-auth-timeout` |
+| Auth Wait Seconds | `IB_AUTH_WAIT_SECONDS` | `--ib-auth-wait-seconds` |
+| Auth Poll Seconds | `IB_AUTH_POLL_SECONDS` | `--ib-auth-poll-seconds` |
 | Force standalone bundled gateway | `IB_FORCE_STANDALONE_GATEWAY` | N/A |
 | Flex Token | `IB_FLEX_TOKEN` | N/A |
 | Read-only mode | `IB_READ_ONLY_MODE` | `--ib-read-only-mode` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,8 @@ export const config = {
   IB_USERNAME: process.env.IB_USERNAME || "",
   IB_PASSWORD_AUTH: process.env.IB_PASSWORD_AUTH || process.env.IB_PASSWORD || "",
   IB_AUTH_TIMEOUT: parseInt(process.env.IB_AUTH_TIMEOUT || "300000"),
+  IB_AUTH_WAIT_SECONDS: parseInt(process.env.IB_AUTH_WAIT_SECONDS || "60"),
+  IB_AUTH_POLL_SECONDS: parseInt(process.env.IB_AUTH_POLL_SECONDS || "5"),
   IB_HEADLESS_MODE: process.env.IB_HEADLESS_MODE === "true",
 
   // Paper trading configuration

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,16 @@ function parseArgs(): z.infer<typeof configSchema> {
           Logger.debug(`🔍 Set IB_AUTH_TIMEOUT to: ${nextArg}`);
           i++;
           break;
+        case 'ib-auth-wait-seconds':
+          args.IB_AUTH_WAIT_SECONDS = parseInt(nextArg);
+          Logger.debug(`🔍 Set IB_AUTH_WAIT_SECONDS to: ${nextArg}`);
+          i++;
+          break;
+        case 'ib-auth-poll-seconds':
+          args.IB_AUTH_POLL_SECONDS = parseInt(nextArg);
+          Logger.debug(`🔍 Set IB_AUTH_POLL_SECONDS to: ${nextArg}`);
+          i++;
+          break;
         case 'ib-headless-mode':
           // Support both --ib-headless-mode (boolean flag) and --ib-headless-mode=true/false
           if (nextArg && !nextArg.startsWith('--')) {
@@ -96,6 +106,14 @@ function parseArgs(): z.infer<typeof configSchema> {
           args.IB_AUTH_TIMEOUT = parseInt(value);
           Logger.debug(`🔍 Set IB_AUTH_TIMEOUT to: ${value}`);
           break;
+        case 'ib-auth-wait-seconds':
+          args.IB_AUTH_WAIT_SECONDS = parseInt(value);
+          Logger.debug(`🔍 Set IB_AUTH_WAIT_SECONDS to: ${value}`);
+          break;
+        case 'ib-auth-poll-seconds':
+          args.IB_AUTH_POLL_SECONDS = parseInt(value);
+          Logger.debug(`🔍 Set IB_AUTH_POLL_SECONDS to: ${value}`);
+          break;
         case 'ib-headless-mode':
           args.IB_HEADLESS_MODE = value.toLowerCase() === 'true';
           Logger.debug(`🔍 Set IB_HEADLESS_MODE to: ${value.toLowerCase() === 'true'} (from value: ${value})`);
@@ -123,6 +141,8 @@ export const configSchema = z.object({
   IB_USERNAME: z.string().optional(),
   IB_PASSWORD_AUTH: z.string().optional(),
   IB_AUTH_TIMEOUT: z.number().optional(),
+  IB_AUTH_WAIT_SECONDS: z.number().optional(),
+  IB_AUTH_POLL_SECONDS: z.number().optional(),
   IB_HEADLESS_MODE: z.boolean().optional(),
 
   // Paper trading configuration
@@ -287,6 +307,8 @@ if (isMainModule) {
     IB_USERNAME: process.env.IB_USERNAME,
     IB_PASSWORD_AUTH: process.env.IB_PASSWORD_AUTH || process.env.IB_PASSWORD,
     IB_AUTH_TIMEOUT: process.env.IB_AUTH_TIMEOUT ? parseInt(process.env.IB_AUTH_TIMEOUT) : undefined,
+    IB_AUTH_WAIT_SECONDS: process.env.IB_AUTH_WAIT_SECONDS ? parseInt(process.env.IB_AUTH_WAIT_SECONDS) : undefined,
+    IB_AUTH_POLL_SECONDS: process.env.IB_AUTH_POLL_SECONDS ? parseInt(process.env.IB_AUTH_POLL_SECONDS) : undefined,
     IB_HEADLESS_MODE: process.env.IB_HEADLESS_MODE === 'true',
     IB_READ_ONLY_MODE: process.env.IB_READ_ONLY_MODE === 'true',
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,8 @@ export const configSchema = z.object({
   IB_USERNAME: z.string().optional(),
   IB_PASSWORD_AUTH: z.string().optional(),
   IB_AUTH_TIMEOUT: z.number().optional(),
+  IB_AUTH_WAIT_SECONDS: z.number().optional(),
+  IB_AUTH_POLL_SECONDS: z.number().optional(),
   IB_HEADLESS_MODE: z.boolean().optional(),
 
   // Paper trading configuration
@@ -85,7 +87,6 @@ export function createIBMCPServer({ config: userConfig }: { config: z.infer<type
 
   return server;
 }
-
 
 
 

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -149,6 +149,7 @@ export class ToolHandlers {
     authPromise: Promise<HeadlessAuthOutcome>,
     maxWaitSeconds: number,
     pollSeconds: number,
+    authenticator: HeadlessAuthenticator,
   ): Promise<{ authenticated: boolean; outcome?: HeadlessAuthOutcome; waitedSeconds: number }> {
     const startedAt = Date.now();
     const deadline = startedAt + maxWaitSeconds * 1000;
@@ -176,12 +177,20 @@ export class ToolHandlers {
       }
     };
 
+    const getWaitedSeconds = (): number => {
+      const elapsed = Math.round((Date.now() - startedAt) / 1000);
+      return Math.min(elapsed, maxWaitSeconds);
+    };
+
     while (Date.now() < deadline) {
       if (outcome?.success || await checkAuthenticated()) {
+        if (!outcome?.browserKeptOpen) {
+          await authenticator.close().catch(() => {});
+        }
         return {
           authenticated: true,
           outcome,
-          waitedSeconds: Math.round((Date.now() - startedAt) / 1000),
+          waitedSeconds: getWaitedSeconds(),
         };
       }
 
@@ -189,7 +198,7 @@ export class ToolHandlers {
         return {
           authenticated: false,
           outcome,
-          waitedSeconds: Math.round((Date.now() - startedAt) / 1000),
+          waitedSeconds: getWaitedSeconds(),
         };
       }
 
@@ -198,17 +207,20 @@ export class ToolHandlers {
     }
 
     if (outcome?.success || await checkAuthenticated()) {
+      if (!outcome?.browserKeptOpen) {
+        await authenticator.close().catch(() => {});
+      }
       return {
         authenticated: true,
         outcome,
-        waitedSeconds: Math.round((Date.now() - startedAt) / 1000),
+        waitedSeconds: getWaitedSeconds(),
       };
     }
 
     return {
       authenticated: false,
       outcome,
-      waitedSeconds: Math.round((Date.now() - startedAt) / 1000),
+      waitedSeconds: getWaitedSeconds(),
     };
   }
 
@@ -269,7 +281,7 @@ export class ToolHandlers {
       }
 
       const { maxWaitSeconds, pollSeconds } = this.getAuthWaitOptions();
-      const waitResult = await this.waitForHeadlessAuthentication(p, maxWaitSeconds, pollSeconds);
+      const waitResult = await this.waitForHeadlessAuthentication(p, maxWaitSeconds, pollSeconds, authenticator);
 
       if (waitResult.authenticated) {
         return { ok: true };

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -42,6 +42,18 @@ type AuthGuardResult =
   | { ok: true }
   | { ok: false; result: ToolHandlerResult };
 
+type HeadlessAuthOutcome = {
+  success: boolean;
+  status?: string;
+  message?: string;
+  error?: string;
+  browserKeptOpen?: boolean;
+};
+
+const DEFAULT_AUTH_WAIT_SECONDS = 60;
+const DEFAULT_AUTH_POLL_SECONDS = 5;
+const DEFAULT_AUTH_CHECK_AGAIN_SECONDS = 10;
+
 export class ToolHandlers {
   private context: ToolHandlerContext;
 
@@ -94,6 +106,112 @@ export class ToolHandlers {
     return this.textResult(JSON.stringify(payload, null, 2));
   }
 
+  private getAuthWaitOptions(): { maxWaitSeconds: number; pollSeconds: number } {
+    const configuredWait = Number(this.context.config.IB_AUTH_WAIT_SECONDS);
+    const configuredPoll = Number(this.context.config.IB_AUTH_POLL_SECONDS);
+
+    const maxWaitSeconds =
+      Number.isFinite(configuredWait) && configuredWait >= 0
+        ? configuredWait
+        : DEFAULT_AUTH_WAIT_SECONDS;
+    const pollSeconds =
+      Number.isFinite(configuredPoll) && configuredPoll > 0
+        ? configuredPoll
+        : DEFAULT_AUTH_POLL_SECONDS;
+
+    return { maxWaitSeconds, pollSeconds };
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private buildAwaitingAuthenticationPayload(
+    authUrl: string,
+    maxWaitSeconds: number,
+    waitedSeconds: number,
+  ): Record<string, unknown> {
+    return {
+      status: "AUTHENTICATION_PENDING",
+      pendingAction: true,
+      requiresUserAction: true,
+      checkAgainSeconds: DEFAULT_AUTH_CHECK_AGAIN_SECONDS,
+      maxWaitSeconds,
+      waitedSeconds,
+      url: authUrl,
+      userAction: "Approve the IBKR two-factor authentication challenge.",
+      message: "IBKR authentication is still pending.",
+      nextInstruction: `Wait ${DEFAULT_AUTH_CHECK_AGAIN_SECONDS} seconds, then check account info again.`,
+    };
+  }
+
+  private async waitForHeadlessAuthentication(
+    authPromise: Promise<HeadlessAuthOutcome>,
+    maxWaitSeconds: number,
+    pollSeconds: number,
+  ): Promise<{ authenticated: boolean; outcome?: HeadlessAuthOutcome; waitedSeconds: number }> {
+    const startedAt = Date.now();
+    const deadline = startedAt + maxWaitSeconds * 1000;
+    let outcome: HeadlessAuthOutcome | undefined;
+
+    authPromise
+      .then((result) => {
+        outcome = result;
+      })
+      .catch((error) => {
+        outcome = {
+          success: false,
+          status: "ERROR",
+          message: "Headless authentication failed.",
+          error: error instanceof Error ? error.message : String(error),
+        };
+      });
+
+    const checkAuthenticated = async (): Promise<boolean> => {
+      try {
+        return await this.context.ibClient.checkAuthenticationStatus();
+      } catch (error) {
+        Logger.debug("[AUTH-WAIT] Auth status check failed while waiting:", error);
+        return false;
+      }
+    };
+
+    while (Date.now() < deadline) {
+      if (outcome?.success || await checkAuthenticated()) {
+        return {
+          authenticated: true,
+          outcome,
+          waitedSeconds: Math.round((Date.now() - startedAt) / 1000),
+        };
+      }
+
+      if (outcome && outcome.status !== "WAITING_FOR_USER_2FA") {
+        return {
+          authenticated: false,
+          outcome,
+          waitedSeconds: Math.round((Date.now() - startedAt) / 1000),
+        };
+      }
+
+      const remainingMs = deadline - Date.now();
+      await this.sleep(Math.min(pollSeconds * 1000, remainingMs));
+    }
+
+    if (outcome?.success || await checkAuthenticated()) {
+      return {
+        authenticated: true,
+        outcome,
+        waitedSeconds: Math.round((Date.now() - startedAt) / 1000),
+      };
+    }
+
+    return {
+      authenticated: false,
+      outcome,
+      waitedSeconds: Math.round((Date.now() - startedAt) / 1000),
+    };
+  }
+
   // Authentication management
   private async ensureAuth(): Promise<AuthGuardResult> {
     // Ensure Gateway is ready first
@@ -115,9 +233,12 @@ export class ToolHandlers {
           ok: false,
           result: this.jsonResult({
             success: false,
-            message: "Headless mode is enabled but authentication credentials are missing.",
-            error: "Set IB_USERNAME and IB_PASSWORD_AUTH to allow automatic headless authentication.",
-            authUrl,
+            status: "AUTHENTICATION_CONFIGURATION_REQUIRED",
+            pendingAction: false,
+            requiresUserAction: true,
+            message: "Headless authentication credentials are missing.",
+            nextInstruction: "Set IB_USERNAME and IB_PASSWORD_AUTH, then check account info again.",
+            url: authUrl,
           }),
         };
       }
@@ -132,9 +253,9 @@ export class ToolHandlers {
       };
 
       // Trigger authentication in the background (non-blocking)
-      Logger.info("⚡ Background headless authentication triggered...");
+      Logger.info("⚡ Headless authentication triggered; waiting briefly for user approval...");
       const authenticator = new HeadlessAuthenticator();
-      const p = authenticator.authenticate(authConfig);
+      const p = authenticator.authenticate(authConfig) as Promise<HeadlessAuthOutcome>;
       if (p && typeof p.then === "function") {
         p.then(async (result) => {
           if (!result.browserKeptOpen) {
@@ -147,16 +268,33 @@ export class ToolHandlers {
         });
       }
 
-      // Throw a standard Error that formatError knows how to parse or that is easy to check
-      const payload = {
-        status: "AUTHENTICATION_STARTED",
-        message: `Headless login has been started in the background, but no 2FA challenge has been verified yet. Re-run this command after the login completes, or open ${authUrl} to inspect the current IBKR authentication screen.`,
-        url: authUrl,
-        requiresAction: true,
-        authStarted: true,
-        twoFactorPending: false,
-        notificationVerified: false
-      };
+      const { maxWaitSeconds, pollSeconds } = this.getAuthWaitOptions();
+      const waitResult = await this.waitForHeadlessAuthentication(p, maxWaitSeconds, pollSeconds);
+
+      if (waitResult.authenticated) {
+        return { ok: true };
+      }
+
+      if (waitResult.outcome && waitResult.outcome.status !== "WAITING_FOR_USER_2FA") {
+        return {
+          ok: false,
+          result: this.jsonResult({
+            success: false,
+            status: waitResult.outcome.status || "AUTHENTICATION_FAILED",
+            pendingAction: false,
+            requiresUserAction: true,
+            message: waitResult.outcome.message || "Headless authentication failed.",
+            error: waitResult.outcome.error,
+            url: authUrl,
+          }),
+        };
+      }
+
+      const payload = this.buildAwaitingAuthenticationPayload(
+        authUrl,
+        maxWaitSeconds,
+        waitResult.waitedSeconds,
+      );
       
       return {
         ok: false,

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ToolHandlers, ToolHandlerContext } from '../src/tool-handlers.js';
 import { IBClient } from '../src/ib-client.js';
 import { IBGatewayManager } from '../src/gateway-manager.js';
+import { HeadlessAuthenticator } from '../src/headless-auth.js';
 import open from 'open';
 
 // Mock dependencies
@@ -19,6 +20,10 @@ describe('ToolHandlers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(HeadlessAuthenticator).mockImplementation(() => ({
+      authenticate: vi.fn().mockReturnValue(new Promise(() => {})),
+      close: vi.fn().mockResolvedValue(undefined),
+    }) as any);
 
     // Create mock IBClient
     mockIBClient = {
@@ -332,27 +337,82 @@ describe('ToolHandlers', () => {
   });
 
   describe('Headless Mode Authentication', () => {
-    it('should trigger auth in headless mode and return a pending response', async () => {
+    it('should leave the already-authenticated path unchanged in headless mode', async () => {
       context.config.IB_HEADLESS_MODE = true;
       context.config.IB_USERNAME = 'testuser';
       context.config.IB_PASSWORD_AUTH = 'testpass';
-      
-      mockIBClient.checkAuthenticationStatus = vi.fn()
-        .mockResolvedValueOnce(false); // Initial check: not authenticated
+      const mockAccounts = [{ id: 'U12345', accountId: 'U12345' }];
+      mockIBClient.checkAuthenticationStatus = vi.fn().mockResolvedValue(true);
+      mockIBClient.getAccountInfo = vi.fn().mockResolvedValue({ accounts: mockAccounts });
 
       handlers = new ToolHandlers(context);
 
       const result = await handlers.getAccountInfo({ confirm: true });
 
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.accounts).toEqual(mockAccounts);
+      expect(mockIBClient.getAccountInfo).toHaveBeenCalled();
+      expect(HeadlessAuthenticator).not.toHaveBeenCalled();
+    });
+
+    it('should continue the original tool call when auth succeeds within the default wait', async () => {
+      vi.useFakeTimers();
+
+      context.config.IB_HEADLESS_MODE = true;
+      context.config.IB_USERNAME = 'testuser';
+      context.config.IB_PASSWORD_AUTH = 'testpass';
+      const mockAccounts = [{ id: 'U12345', accountId: 'U12345' }];
+      mockIBClient.getAccountInfo = vi.fn().mockResolvedValue({ accounts: mockAccounts });
+      mockIBClient.checkAuthenticationStatus = vi.fn()
+        .mockResolvedValue(false);
+      vi.mocked(HeadlessAuthenticator).mockImplementation(() => ({
+        authenticate: vi.fn().mockReturnValue(new Promise((resolve) => {
+          setTimeout(() => resolve({ success: true, status: 'SUCCESS' }), 5_000);
+        })),
+        close: vi.fn().mockResolvedValue(undefined),
+      }) as any);
+
+      handlers = new ToolHandlers(context);
+
+      const resultPromise = handlers.getAccountInfo({ confirm: true });
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await resultPromise;
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.accounts).toEqual(mockAccounts);
+      expect(mockIBClient.getAccountInfo).toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+
+    it('should wait the default auth window before returning concise pending metadata', async () => {
+      vi.useFakeTimers();
+
+      context.config.IB_HEADLESS_MODE = true;
+      context.config.IB_USERNAME = 'testuser';
+      context.config.IB_PASSWORD_AUTH = 'testpass';
+      mockIBClient.checkAuthenticationStatus = vi.fn().mockResolvedValue(false);
+
+      handlers = new ToolHandlers(context);
+
+      const resultPromise = handlers.getAccountInfo({ confirm: true });
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await resultPromise;
+
       expect(result.content).toBeDefined();
       const payload = JSON.parse(result.content[0].text);
-      expect(payload.status).toBe('AUTHENTICATION_STARTED');
-      expect(payload.requiresAction).toBe(true);
+      expect(payload.status).toBe('AUTHENTICATION_PENDING');
+      expect(payload.pendingAction).toBe(true);
+      expect(payload.requiresUserAction).toBe(true);
+      expect(payload.checkAgainSeconds).toBe(10);
+      expect(payload.maxWaitSeconds).toBe(60);
+      expect(payload.waitedSeconds).toBe(60);
       expect(payload.url).toContain('5000');
-      expect(payload.authStarted).toBe(true);
-      expect(payload.twoFactorPending).toBe(false);
-      expect(payload.notificationVerified).toBe(false);
-      expect(payload.message).not.toContain('push notification');
+      expect(payload.userAction).toContain('Approve');
+      expect(payload.nextInstruction).toBe('Wait 10 seconds, then check account info again.');
+      expect(payload.message).toBe('IBKR authentication is still pending.');
+      expect(JSON.stringify(payload).toLowerCase()).not.toContain('retry');
+      expect(mockIBClient.getAccountInfo).not.toHaveBeenCalled();
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
## Summary
- wait up to 60 seconds for headless IBKR auth to complete before returning from auth-gated tools
- return concise machine-actionable AUTHENTICATION_PENDING metadata when user 2FA approval is still pending
- add configurable auth wait/poll seconds and document the pending-auth behavior

## Verification
- npm test
- npm run build
- npm run lint (passes with existing warnings)
- git diff --check