### PR TITLE
Restore blocking headless authentication

### DIFF
--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -255,62 +255,54 @@ export class ToolHandlers {
         };
       }
 
+      const authTimeout = Number(this.context.config.IB_AUTH_TIMEOUT) || 300000;
+
       const authConfig: HeadlessAuthConfig = {
         url: authUrl,
         username: this.context.config.IB_USERNAME,
         password: this.context.config.IB_PASSWORD_AUTH,
-        timeout: this.context.config.IB_AUTH_TIMEOUT,
+        timeout: authTimeout,
         ibClient: this.context.ibClient, // Pass the IB client for authentication checking
         paperTrading: this.context.config.IB_PAPER_TRADING,
       };
 
-      // Trigger authentication in the background (non-blocking)
-      Logger.info("⚡ Headless authentication triggered; waiting briefly for user approval...");
+      Logger.info("⚡ Headless authentication triggered; waiting for full authentication (blocking)...");
       const authenticator = new HeadlessAuthenticator();
-      const p = authenticator.authenticate(authConfig) as Promise<HeadlessAuthOutcome>;
-      if (p && typeof p.then === "function") {
-        p.then(async (result) => {
-          if (!result.browserKeptOpen) {
-            await authenticator.close().catch(() => {});
-          }
-          Logger.info(`🎯 Background headless authentication completed: success=${result.success}`);
-        }).catch(async (err) => {
-          await authenticator.close().catch(() => {});
-          Logger.error("❌ Background headless authentication failed:", err);
-        });
-      }
+      const outcome = await authenticator.authenticate(authConfig);
 
-      const { maxWaitSeconds, pollSeconds } = this.getAuthWaitOptions();
-      const waitResult = await this.waitForHeadlessAuthentication(p, maxWaitSeconds, pollSeconds, authenticator);
-
-      if (waitResult.authenticated) {
+      if (outcome.success) {
         return { ok: true };
       }
 
-      if (waitResult.outcome && waitResult.outcome.status !== "WAITING_FOR_USER_2FA") {
+      if (outcome.status === "WAITING_FOR_USER_2FA") {
         return {
           ok: false,
           result: this.jsonResult({
-            success: false,
-            status: waitResult.outcome.status || "AUTHENTICATION_FAILED",
-            pendingAction: false,
+            status: "AUTHENTICATION_PENDING",
+            pendingAction: true,
             requiresUserAction: true,
-            message: waitResult.outcome.message || "Headless authentication failed.",
-            error: waitResult.outcome.error,
+            checkAgainSeconds: DEFAULT_AUTH_CHECK_AGAIN_SECONDS,
+            maxWaitSeconds: Math.round(authTimeout / 1000),
+            waitedSeconds: Math.round(authTimeout / 1000),
             url: authUrl,
+            userAction: "Approve the IBKR two-factor authentication challenge.",
+            message: outcome.message || "IBKR authentication is still pending.",
+            nextInstruction: `Wait ${DEFAULT_AUTH_CHECK_AGAIN_SECONDS} seconds, then check account info again.`,
           }),
         };
       }
 
-      const payload = this.buildAwaitingAuthenticationPayload(
-        authUrl,
-        maxWaitSeconds,
-        waitResult.waitedSeconds,
-      );
-      
       return {
         ok: false,
-        result: this.jsonResult(payload),
+        result: this.jsonResult({
+          success: false,
+          status: outcome.status || "AUTHENTICATION_FAILED",
+          pendingAction: false,
+          requiresUserAction: true,
+          message: outcome.message || "Headless authentication failed.",
+          error: outcome.error,
+          url: authUrl,
+        }),
       };
     } else {
       // In non-headless mode, check if the gateway is already authenticated

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -356,8 +356,6 @@ describe('ToolHandlers', () => {
     });
 
     it('should continue the original tool call when auth succeeds within the default wait', async () => {
-      vi.useFakeTimers();
-
       context.config.IB_HEADLESS_MODE = true;
       context.config.IB_USERNAME = 'testuser';
       context.config.IB_PASSWORD_AUTH = 'testpass';
@@ -366,37 +364,37 @@ describe('ToolHandlers', () => {
       mockIBClient.checkAuthenticationStatus = vi.fn()
         .mockResolvedValue(false);
       vi.mocked(HeadlessAuthenticator).mockImplementation(() => ({
-        authenticate: vi.fn().mockReturnValue(new Promise((resolve) => {
-          setTimeout(() => resolve({ success: true, status: 'SUCCESS' }), 5_000);
-        })),
+        authenticate: vi.fn().mockResolvedValue({ success: true, status: 'SUCCESS' }),
         close: vi.fn().mockResolvedValue(undefined),
       }) as any);
 
       handlers = new ToolHandlers(context);
 
-      const resultPromise = handlers.getAccountInfo({ confirm: true });
-      await vi.advanceTimersByTimeAsync(5_000);
-      const result = await resultPromise;
+      const result = await handlers.getAccountInfo({ confirm: true });
 
       const payload = JSON.parse(result.content[0].text);
       expect(payload.accounts).toEqual(mockAccounts);
       expect(mockIBClient.getAccountInfo).toHaveBeenCalled();
-      vi.useRealTimers();
     });
 
-    it('should wait the default auth window before returning concise pending metadata', async () => {
-      vi.useFakeTimers();
-
+    it('should wait up to the timeout before returning concise pending metadata if auth is waiting for 2FA', async () => {
       context.config.IB_HEADLESS_MODE = true;
       context.config.IB_USERNAME = 'testuser';
       context.config.IB_PASSWORD_AUTH = 'testpass';
+      context.config.IB_AUTH_TIMEOUT = 10000; // 10 seconds for test
       mockIBClient.checkAuthenticationStatus = vi.fn().mockResolvedValue(false);
+      vi.mocked(HeadlessAuthenticator).mockImplementation(() => ({
+        authenticate: vi.fn().mockResolvedValue({
+          success: false,
+          status: 'WAITING_FOR_USER_2FA',
+          message: 'IBKR reports that it sent a mobile notification and is waiting for approval'
+        }),
+        close: vi.fn().mockResolvedValue(undefined),
+      }) as any);
 
       handlers = new ToolHandlers(context);
 
-      const resultPromise = handlers.getAccountInfo({ confirm: true });
-      await vi.advanceTimersByTimeAsync(60_000);
-      const result = await resultPromise;
+      const result = await handlers.getAccountInfo({ confirm: true });
 
       expect(result.content).toBeDefined();
       const payload = JSON.parse(result.content[0].text);
@@ -404,15 +402,14 @@ describe('ToolHandlers', () => {
       expect(payload.pendingAction).toBe(true);
       expect(payload.requiresUserAction).toBe(true);
       expect(payload.checkAgainSeconds).toBe(10);
-      expect(payload.maxWaitSeconds).toBe(60);
-      expect(payload.waitedSeconds).toBe(60);
+      expect(payload.maxWaitSeconds).toBe(10);
+      expect(payload.waitedSeconds).toBe(10);
       expect(payload.url).toContain('5000');
       expect(payload.userAction).toContain('Approve');
       expect(payload.nextInstruction).toBe('Wait 10 seconds, then check account info again.');
-      expect(payload.message).toBe('IBKR authentication is still pending.');
+      expect(payload.message).toBe('IBKR reports that it sent a mobile notification and is waiting for approval');
       expect(JSON.stringify(payload).toLowerCase()).not.toContain('retry');
       expect(mockIBClient.getAccountInfo).not.toHaveBeenCalled();
-      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
This PR reverts the non-blocking headless authentication flow in 'interactive-brokers-mcp' to restore the original, highly reliable blocking headless authentication behavior.