### PR TITLE
fix: harden Client Portal brokerage auth init

### DIFF
--- a/src/headless-auth.ts
+++ b/src/headless-auth.ts
@@ -179,6 +179,26 @@ export class HeadlessAuthenticator {
           if (authConfig.ibClient && credentialsSubmitted) {
             const cookies = await this.page.context().cookies();
             authConfig.ibClient.setSessionCookies(cookies);
+
+            const now = Date.now();
+            if (now - lastBrokerageInitAttempt > 15000) {
+              lastBrokerageInitAttempt = now;
+              try {
+                const initialized = await authConfig.ibClient.initializeBrokerageSession();
+                if (initialized) {
+                  Logger.info('🎉 Authentication completed! Brokerage session initialized after SSO/mobile approval.');
+                  await this.cleanup();
+
+                  return {
+                    success: true,
+                    status: 'SUCCESS',
+                    message: 'Headless authentication completed successfully. Brokerage session initialized after SSO/mobile approval.'
+                  };
+                }
+              } catch (error: any) {
+                Logger.debug('Brokerage session initialization not ready yet, continuing...', error?.message || String(error));
+              }
+            }
           }
 
           // Check if we successfully authenticated by looking for the specific success message

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -477,7 +477,8 @@ export class IBClient {
     const runOfficialSequence = async (client: AxiosInstance, labelPrefix: string, expectFinal = false): Promise<any> => {
       Logger.log(`[BROKERAGE-INIT] Running official Gateway brokerage sequence (${labelPrefix})...`);
 
-      await tryRequest(`${labelPrefix} GET /v1/api/sso/validate`, () => client.get("/sso/validate"));
+      const ssoValidateResponse = await tryRequest(`${labelPrefix} GET /v1/api/sso/validate`, () => client.get("/sso/validate"));
+      const ssoValidation = ssoValidateResponse?.data || {};
       let statusResponse = await tryRequest(`${labelPrefix} GET /v1/api/iserver/auth/status`, () => client.get("/iserver/auth/status"));
       if (this.isStatusAuthenticated(statusResponse?.data)) {
         return statusResponse?.data;
@@ -488,9 +489,19 @@ export class IBClient {
       await tryRequest(`${labelPrefix} GET /v1/api/iserver/accounts`, () => client.get("/iserver/accounts"));
 
       const authStatus = statusResponse?.data || {};
-      const rawMac = String(authStatus.MAC || "");
-      const rawHardware = String(authStatus.hardware_info || "");
-      const machineId = rawHardware.split("|")[0] || "";
+      // Some Gateway/SSO combinations report HARDWARE_INFO only from
+      // /sso/validate after mobile 2FA succeeds, while /iserver/auth/status
+      // still omits hardware_info until ssodh/init runs. In that state, using
+      // an empty ssodh/init body can leave authenticated=false indefinitely.
+      // Keep machineId and MAC from the same source when falling back to SSO.
+      const authHardware = String(authStatus.hardware_info || "");
+      const ssoHardware = String(ssoValidation.HARDWARE_INFO || "");
+      const rawHardware = authHardware || ssoHardware;
+      const hardwareParts = rawHardware.split("|");
+      const machineId = hardwareParts[0] || "";
+      const rawMac = authHardware
+        ? String(authStatus.MAC || hardwareParts[1] || "")
+        : String(hardwareParts[1] || authStatus.MAC || "");
       const mac = rawMac.replaceAll(":", "-");
 
       if (machineId && mac) {

--- a/test/headless-auth.test.ts
+++ b/test/headless-auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { BrowserInstaller } from '../src/browser-installer.js';
 import { HeadlessAuthenticator } from '../src/headless-auth.js';
 
 describe('HeadlessAuthenticator state detection', () => {
@@ -61,5 +62,64 @@ describe('HeadlessAuthenticator state detection', () => {
       detected: true,
     });
     expect(state.message).toContain('invalid username');
+  });
+});
+
+describe('HeadlessAuthenticator authenticate', () => {
+  it('initializes the brokerage session before waiting for the browser success message', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    const cookies = [{ name: 'SBID', value: 'abc', domain: 'localhost' }];
+    const page = {
+      setDefaultTimeout: vi.fn(),
+      goto: vi.fn().mockResolvedValue(undefined),
+      waitForSelector: vi.fn().mockResolvedValue(undefined),
+      fill: vi.fn().mockResolvedValue(undefined),
+      click: vi.fn().mockResolvedValue(undefined),
+      url: vi.fn(() => 'https://localhost:5000/sso/pending'),
+      content: vi.fn().mockResolvedValue('<html>Waiting for mobile approval</html>'),
+      context: vi.fn(() => ({ cookies: vi.fn().mockResolvedValue(cookies) })),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const browser = {
+      newPage: vi.fn().mockResolvedValue(page),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const launchSpy = vi
+      .spyOn(BrowserInstaller, 'launchLocalBrowser')
+      .mockResolvedValue(browser as any);
+    const ibClient = {
+      checkAuthenticationStatus: vi.fn().mockResolvedValue(false),
+      setSessionCookies: vi.fn(),
+      initializeBrokerageSession: vi.fn().mockResolvedValue(true),
+    };
+
+    try {
+      const authenticator = new HeadlessAuthenticator();
+      const authPromise = authenticator.authenticate({
+        url: 'https://localhost:5000',
+        username: 'user',
+        password: 'pass',
+        timeout: 10_000,
+        ibClient: ibClient as any,
+      });
+
+      await vi.advanceTimersByTimeAsync(3000);
+      const result = await authPromise;
+
+      expect(ibClient.checkAuthenticationStatus).toHaveBeenCalled();
+      expect(ibClient.setSessionCookies).toHaveBeenCalledWith(cookies);
+      expect(ibClient.initializeBrokerageSession).toHaveBeenCalledTimes(1);
+      expect(page.content).toHaveBeenCalled();
+      expect(result).toMatchObject({
+        success: true,
+        status: 'SUCCESS',
+      });
+      expect(result.message).toContain('Brokerage session initialized after SSO/mobile approval');
+    } finally {
+      launchSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 });

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -743,6 +743,57 @@ describe('IBClient', () => {
       expect(mockAuthClient.post).toHaveBeenCalledWith('/tickle');
     });
 
+    it('should initialize brokerage session using SSO HARDWARE_INFO when auth status omits hardware_info', async () => {
+      const mockAuthClient = {
+        post: vi.fn().mockResolvedValue({ data: {}, status: 200 }),
+        get: vi.fn()
+          .mockResolvedValueOnce({
+            data: {
+              RESULT: true,
+              HARDWARE_INFO: '71a482fc|06:7F:1D:C4:36:2F',
+            },
+            status: 200,
+          })
+          .mockResolvedValueOnce({
+            data: {
+              authenticated: false,
+              connected: true,
+              MAC: 'AA:AA:AA:AA:AA:AA',
+            },
+            status: 200,
+          })
+          .mockRejectedValueOnce(new Error('not ready'))
+          .mockResolvedValueOnce({ data: {}, status: 200 })
+          .mockResolvedValueOnce({ data: [], status: 200 })
+          .mockResolvedValueOnce({
+            data: { authenticated: true, connected: true, established: true },
+            status: 200,
+          }),
+      };
+
+      vi.mocked(axios.create).mockReturnValueOnce(mockAuthClient as any);
+
+      await expect(client.initializeBrokerageSession()).resolves.toBe(true);
+
+      expect(mockAuthClient.post).toHaveBeenCalledWith(
+        '/iserver/auth/ssodh/init',
+        expect.stringContaining('machineId=71a482fc'),
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        })
+      );
+      expect(mockAuthClient.post).toHaveBeenCalledWith(
+        '/iserver/auth/ssodh/init',
+        expect.stringContaining('mac=06-7F-1D-C4-36-2F'),
+        expect.any(Object)
+      );
+      expect(mockAuthClient.post).not.toHaveBeenCalledWith(
+        '/iserver/auth/ssodh/init',
+        expect.stringContaining('mac=AA-AA-AA-AA-AA-AA'),
+        expect.any(Object)
+      );
+    });
+
     it('should handle reauth when final status returns false', async () => {
       const mockAuthClient = {
         post: vi.fn().mockResolvedValue({ data: {} }),


### PR DESCRIPTION
This PR hardens Interactive Brokers Client Portal Gateway authentication in two broker-safe edge cases observed with headless browser login and mobile/SSO approval flows:

- Reuse `HARDWARE_INFO` from `/sso/validate` when `/iserver/auth/status` does not yet include lowercase `hardware_info`, so `ssodh/init` can still be called with the official form body.
- After browser credentials are submitted, copy localhost Gateway cookies and periodically attempt brokerage-session initialization before waiting for the literal `Client login succeeds` page marker.

## Why

Some Gateway/SSO states can have a valid browser/mobile approval state while `/iserver/auth/status` is not yet established. In those states:

1. `/sso/validate` can expose `HARDWARE_INFO`, but `/iserver/auth/status` may omit `hardware_info` until after `ssodh/init`.
2. The REST brokerage session may be initializable before the browser page renders the exact `Client login succeeds` text.

Without these fallbacks, headless auth can wait or time out even though the Gateway has enough state to establish the brokerage session.

## Changes

- `src/ib-client.ts`
  - Preserve `/sso/validate` response in `initializeBrokerageSession()`.
  - Fall back from `authStatus.hardware_info` to `ssoValidation.HARDWARE_INFO`.
  - When falling back to SSO hardware data, derive both `machineId` and `mac` from the same `HARDWARE_INFO` payload before posting `/iserver/auth/ssodh/init`.

- `src/headless-auth.ts`
  - After credentials are submitted and Playwright cookies are available, set Gateway cookies on the IB client.
  - Every 15 seconds, call `initializeBrokerageSession()` even before the browser page shows `Client login succeeds`.
  - Return success immediately if the brokerage session is established through this path.

- Tests
  - Added coverage for uppercase SSO `HARDWARE_INFO` fallback when auth status lacks lowercase `hardware_info`.
  - Added coverage that headless auth can succeed through pre-success brokerage-session initialization even when the page text does not contain `Client login succeeds`.

## Test plan

Ran locally, without contacting IBKR or starting any broker login/auth flow:

```bash
npm test -- --run test/ib-client.test.ts test/headless-auth.test.ts
npm test
npm run build
```

Results:

- Targeted tests: `2 passed`, `43 passed | 1 skipped`
- Full test suite: `8 passed`, `183 passed | 1 skipped`
- Build: passed

Note: the existing full test suite still emits non-fatal `MaxListenersExceededWarning` warnings, unchanged by this PR.
