### PR TITLE
fix: Windows support for bundled gateway startup

### DIFF
--- a/src/gateway-manager.ts
+++ b/src/gateway-manager.ts
@@ -669,7 +669,7 @@ export class IBGatewayManager {
       const runtimePath = path.join(this.gatewayDir, 'clientportal.gw/build/lib/runtime/*');
       const configDir = path.join(this.gatewayDir, 'clientportal.gw/root');
       
-      const classpath = `${configDir}:${jarPath}:${runtimePath}`;
+      const classpath = [configDir, jarPath, runtimePath].join(path.delimiter);
 
       this.log('🚀 Starting IB Gateway with bundled JRE...');
       this.log('   Java: ' + bundledJavaPath);

--- a/src/utils/port-utils.ts
+++ b/src/utils/port-utils.ts
@@ -1,39 +1,24 @@
 import { exec } from 'child_process';
+import net from 'net';
 import os from 'os';
 import { Logger } from '../logger.js';
 
 export class PortUtils {
   static async isPortAvailable(port: number): Promise<boolean> {
+    // Probe by actually attempting to bind the port. This is accurate and
+    // cross-platform; the previous `netstat | findstr :PORT` approach matched
+    // substrings (e.g. ":5000" also matched ephemeral ":50001"), producing
+    // false negatives on Windows that forced the Gateway off its default port.
     return new Promise((resolve) => {
-      const platform = os.platform();
-      let command: string;
-      
-      // Use OS-specific commands to check if port is in use
-      switch (platform) {
-        case 'win32':
-          command = `netstat -an | findstr :${port}`;
-          break;
-        case 'darwin':
-          command = `lsof -i :${port}`;
-          break;
-        case 'linux':
-          command = `ss -tuln | grep ":${port} " || netstat -tuln | grep ":${port} "`;
-          break;
-        default:
-          command = `netstat -an | grep "\\.${port} "`;
-          break;
-      }
-      
-      exec(command, (error, stdout) => {
-        if (error) {
-          // Command failed or no processes found using the port - port is available
-          resolve(true);
-        } else {
-          // Command succeeded and found processes using the port - port is not available
-          const output = stdout.trim();
-          resolve(output === '');
-        }
+      const tester = net.createServer();
+      tester.once('error', () => {
+        // EADDRINUSE (or EACCES) -> not available for us to bind
+        resolve(false);
       });
+      tester.once('listening', () => {
+        tester.close(() => resolve(true));
+      });
+      tester.listen(port, '0.0.0.0');
     });
   }
 


### PR DESCRIPTION
## Summary

Two small portability fixes so the bundled Client Portal Gateway starts and connects on Windows. macOS/Linux behavior is unchanged.

## Background

On Windows the gateway never started; after working that around it came up on the wrong port, so tools kept reporting "authenticate first" even after a successful browser login.

## Changes

**1. Classpath separator (`gateway-manager.ts`)** — the classpath was joined with a literal `":"`. On Windows the separator is `";"` (and `":"` is part of drive letters like `C:\`), so the JVM couldn't locate the gateway classes:

```
Could not find or load main class ibgroup.web.core.clientportal.gw.GatewayStart
Caused by: java.lang.ClassNotFoundException
```

Joining with `path.delimiter` makes it correct on every platform.

**2. Port availability check (`port-utils.ts`)** — `isPortAvailable` ran `netstat -an | findstr :PORT`, a substring match: checking `5000` also matches ephemeral ports like `50001`. One is almost always present on Windows, so `5000` looked busy and the gateway moved to `5001` while the REST client kept using `5000` — the browser session authenticated but the client never saw it. Replaced with a direct bind attempt via the `net` module: accurate and shell-free.

## Testing

Windows 10 + Node 24: gateway now starts on `5000`, browser auth completes, and `get_account_info` / `get_positions` / `get_market_data` return data. macOS/Linux logic is unchanged (`path.delimiter` is `:` there; the bind probe is platform-agnostic).
