### PR TITLE
fix(2fa): handle IBKR multi-device second-factor chooser for TOTP

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,7 @@ export const config = {
   IB_SELECTOR_LOGIN_SUBMIT: process.env.IB_SELECTOR_LOGIN_SUBMIT || "",
   IB_SELECTOR_TOTP_INPUT: process.env.IB_SELECTOR_TOTP_INPUT || "",
   IB_SELECTOR_TOTP_SUBMIT: process.env.IB_SELECTOR_TOTP_SUBMIT || "",
+  IB_SELECTOR_TOTP_DEVICE_SELECT: process.env.IB_SELECTOR_TOTP_DEVICE_SELECT || "",
 
   // Flex Query configuration
   IB_FLEX_TOKEN: process.env.IB_FLEX_TOKEN || "",

--- a/src/headless-auth.ts
+++ b/src/headless-auth.ts
@@ -13,6 +13,7 @@ export interface AuthSelectorOverrides {
   loginSubmit?: string;
   totpInput?: string;
   totpSubmit?: string;
+  totpDeviceSelect?: string;
 }
 
 export interface HeadlessAuthConfig {
@@ -168,6 +169,7 @@ export class HeadlessAuthenticator {
               secret: authConfig.totpSecret,
               inputSelector: authConfig.selectors?.totpInput,
               submitSelector: authConfig.selectors?.totpSubmit,
+              deviceSelectSelector: authConfig.selectors?.totpDeviceSelect,
             })
           : null;
 
@@ -287,7 +289,13 @@ export class HeadlessAuthenticator {
           if (twoFactorState.detected) {
             Logger.info(`🔐 ${twoFactorState.message} - continuing to wait...`);
 
-            if (totpHandler && twoFactorState.method === 'security_code') {
+            // `factor_selection` is the multi-device chooser that precedes the
+            // security-code field; the handler selects the authenticator device
+            // and then submits, so drive it for both states.
+            if (
+              totpHandler &&
+              (twoFactorState.method === 'security_code' || twoFactorState.method === 'factor_selection')
+            ) {
               if (totpHandler.exhausted) {
                 // IBKR permanently locks accounts after repeated 2FA failures;
                 // stop instead of resubmitting codes for the rest of the timeout.
@@ -430,7 +438,12 @@ export class HeadlessAuthenticator {
       };
     }
 
-    if (text.includes('temporary security code') || text.includes('security code') || text.includes('response code')) {
+    if (
+      text.includes('temporary security code') ||
+      text.includes('security code') ||
+      text.includes('response code') ||
+      text.includes('authenticator app code')
+    ) {
       return {
         detected: true,
         method: 'security_code',

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -109,6 +109,7 @@ export class ToolHandlers {
         loginSubmit: config.IB_SELECTOR_LOGIN_SUBMIT || undefined,
         totpInput: config.IB_SELECTOR_TOTP_INPUT || undefined,
         totpSubmit: config.IB_SELECTOR_TOTP_SUBMIT || undefined,
+        totpDeviceSelect: config.IB_SELECTOR_TOTP_DEVICE_SELECT || undefined,
       },
     };
   }

--- a/src/totp-strategy.ts
+++ b/src/totp-strategy.ts
@@ -9,6 +9,8 @@ interface TotpChallengeOptions {
   inputSelector?: string;
   /** CSS selector (list) for the submit control. Defaults to the known IBKR selectors. */
   submitSelector?: string;
+  /** CSS selector for the second-factor-device chooser. Defaults to `select`. */
+  deviceSelectSelector?: string;
   /** Total submissions allowed before the handler reports itself exhausted. */
   maxAttempts?: number;
 }
@@ -16,7 +18,19 @@ interface TotpChallengeOptions {
 // Selectors matching the security-code form on current IBKR login pages.
 // Overridable via IB_SELECTOR_TOTP_INPUT / IB_SELECTOR_TOTP_SUBMIT when IBKR
 // changes its markup.
+//
+// The current IBKR "XYZ" login widget renders the authenticator/security-code
+// field as #xyz-field-silver-response (placeholder "Mobile Authenticator App
+// Code"), with #xyz-field-gold-response / #xyz-field-temp-response used for the
+// response-card and temporary-code variants. The older ids are kept as
+// fallbacks for other Gateway builds.
 export const DEFAULT_TOTP_INPUT_SELECTOR = [
+  'input#xyz-field-silver-response',
+  'input[name="silver-response"]',
+  'input#xyz-field-gold-response',
+  'input[name="gold-response"]',
+  'input#xyz-field-temp-response',
+  'input[name="temp-response"]',
   'input#chg_response',
   'input[name="chg_response"]',
   'input[name="response"]',
@@ -25,10 +39,21 @@ export const DEFAULT_TOTP_INPUT_SELECTOR = [
 ].join(', ');
 
 export const DEFAULT_TOTP_SUBMIT_SELECTOR = [
+  'button.xyz-button-login',
   'input[type="submit"]',
   'button[type="submit"]',
   'button#submitForm',
 ].join(', ');
+
+// When an account has more than one second-factor device enrolled, IBKR first
+// shows a native <select> asking which device to use. We must pick the
+// authenticator-app option before the security-code field is rendered.
+// Overridable via IB_SELECTOR_TOTP_DEVICE_SELECT.
+export const DEFAULT_TOTP_DEVICE_SELECT_SELECTOR = 'select';
+
+// Matches the authenticator-app option label in the device chooser
+// (e.g. "Mobile Authenticator App").
+const AUTHENTICATOR_OPTION_PATTERN = /authenticator/i;
 
 // A code submitted this close to rollover may expire before IBKR validates it.
 const MIN_SECONDS_LEFT_IN_WINDOW = 8;
@@ -48,6 +73,7 @@ export class TotpChallengeHandler {
   private readonly totp: OTPAuth.TOTP;
   private readonly inputSelector: string;
   private readonly submitSelector: string;
+  private readonly deviceSelectSelector: string;
   private readonly maxAttempts: number;
   private attempts = 0;
   private lastAttemptWindow = -1;
@@ -58,7 +84,44 @@ export class TotpChallengeHandler {
     });
     this.inputSelector = options.inputSelector || DEFAULT_TOTP_INPUT_SELECTOR;
     this.submitSelector = options.submitSelector || DEFAULT_TOTP_SUBMIT_SELECTOR;
+    this.deviceSelectSelector = options.deviceSelectSelector || DEFAULT_TOTP_DEVICE_SELECT_SELECTOR;
     this.maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  }
+
+  /**
+   * When IBKR shows the "Select Second Factor Device" chooser (accounts with
+   * more than one enrolled 2FA device), pick the authenticator-app option so
+   * the security-code field is rendered. No-op when the chooser is absent
+   * (single-device accounts land straight on the code field). Returns true when
+   * a selection was made.
+   */
+  private async selectAuthenticatorDevice(page: Page): Promise<boolean> {
+    const select = page.locator(this.deviceSelectSelector).filter({ visible: true }).first();
+    if ((await select.count()) === 0) {
+      return false;
+    }
+
+    const optionLabels = await select.locator('option').allTextContents();
+    const authenticatorLabel = optionLabels
+      .map((label) => label.trim())
+      .find((label) => AUTHENTICATOR_OPTION_PATTERN.test(label));
+
+    if (!authenticatorLabel) {
+      return false;
+    }
+
+    // Already on the authenticator option (e.g. we selected it on a previous
+    // poll); nothing to do.
+    const current = (await select.locator('option:checked').first().textContent().catch(() => null))?.trim();
+    if (current && AUTHENTICATOR_OPTION_PATTERN.test(current)) {
+      return false;
+    }
+
+    Logger.info(`🔐 Selecting second-factor device "${authenticatorLabel}"...`);
+    await select.selectOption({ label: authenticatorLabel });
+    // Let the widget render the security-code field before we look for it.
+    await page.waitForTimeout(1000);
+    return true;
   }
 
   get exhausted(): boolean {
@@ -83,6 +146,11 @@ export class TotpChallengeHandler {
       return false;
     }
 
+    // Multi-device accounts show a device chooser before the code field. This
+    // is idempotent and cheap, so run it on every attempt before checking the
+    // TOTP window (selecting a device sends nothing to the phone).
+    await this.selectAuthenticatorDevice(page);
+
     const secondsLeft = this.secondsLeftInWindow();
     if (secondsLeft < MIN_SECONDS_LEFT_IN_WINDOW) {
       Logger.info(`⏳ Only ${secondsLeft}s left in the current TOTP window; waiting for the next one...`);
@@ -101,10 +169,13 @@ export class TotpChallengeHandler {
     const token = this.totp.generate();
     Logger.info(`🔑 Submitting TOTP security code (attempt ${this.attempts}/${this.maxAttempts})...`);
 
-    const input = page.locator(this.inputSelector).first();
+    // The credentials form leaves hidden response inputs and login buttons in
+    // the DOM, so scope to visible elements to avoid filling/clicking a hidden
+    // one.
+    const input = page.locator(this.inputSelector).filter({ visible: true }).first();
     await input.waitFor({ state: 'visible', timeout: 10000 });
     await input.fill(token);
-    await page.locator(this.submitSelector).first().click();
+    await page.locator(this.submitSelector).filter({ visible: true }).first().click();
     Logger.info('🚀 Security code filled and submitted.');
 
     // Give the submission a moment to register before the next status poll.

--- a/src/totp-strategy.ts
+++ b/src/totp-strategy.ts
@@ -119,8 +119,8 @@ export class TotpChallengeHandler {
 
     Logger.info(`🔐 Selecting second-factor device "${authenticatorLabel}"...`);
     await select.selectOption({ label: authenticatorLabel });
-    // Let the widget render the security-code field before we look for it.
-    await page.waitForTimeout(1000);
+    // No sleep needed: submitCode() waits for the security-code input to become
+    // visible before filling it, which covers the widget's render time.
     return true;
   }
 
@@ -163,17 +163,22 @@ export class TotpChallengeHandler {
       return false;
     }
 
+    // Locate and wait for the visible code input before committing an attempt.
+    // If it never appears (e.g. the chooser had no authenticator option, or the
+    // widget failed to render), this throws without consuming the attempt
+    // budget, so the caller can retry on a later poll instead of the handler
+    // becoming `exhausted` having never submitted a code.
+    // The credentials form leaves hidden response inputs and login buttons in
+    // the DOM, so scope to visible elements to avoid filling/clicking a hidden one.
+    const input = page.locator(this.inputSelector).filter({ visible: true }).first();
+    await input.waitFor({ state: 'visible', timeout: 10000 });
+
     this.lastAttemptWindow = this.currentWindow();
     this.attempts += 1;
 
     const token = this.totp.generate();
     Logger.info(`🔑 Submitting TOTP security code (attempt ${this.attempts}/${this.maxAttempts})...`);
 
-    // The credentials form leaves hidden response inputs and login buttons in
-    // the DOM, so scope to visible elements to avoid filling/clicking a hidden
-    // one.
-    const input = page.locator(this.inputSelector).filter({ visible: true }).first();
-    await input.waitFor({ state: 'visible', timeout: 10000 });
     await input.fill(token);
     await page.locator(this.submitSelector).filter({ visible: true }).first().click();
     Logger.info('🚀 Security code filled and submitted.');

--- a/test/headless-auth.test.ts
+++ b/test/headless-auth.test.ts
@@ -6,6 +6,7 @@ import {
   TotpChallengeHandler,
   DEFAULT_TOTP_INPUT_SELECTOR,
   DEFAULT_TOTP_SUBMIT_SELECTOR,
+  DEFAULT_TOTP_DEVICE_SELECT_SELECTOR,
 } from '../src/totp-strategy.js';
 
 const TEST_SECRET = 'MZXW6YTB'; // base32 for 'foobar'
@@ -150,7 +151,7 @@ describe('TotpChallengeHandler', () => {
     });
     const page: any = {
       locator: vi.fn((selector: string) => {
-        if (selector === 'select') return selectMock;
+        if (selector === DEFAULT_TOTP_DEVICE_SELECT_SELECTOR) return selectMock;
         if (!elements.has(selector)) {
           const el = makeEl();
           elements.set(selector, { filter: vi.fn(() => ({ first: () => el })), first: () => el, _el: el });

--- a/test/headless-auth.test.ts
+++ b/test/headless-auth.test.ts
@@ -23,19 +23,31 @@ function expectedTokenAt(timestampMs: number): string {
 
 function createMockPage() {
   const elements = new Map<string, any>();
+  const makeLocator = (selector: string): any => {
+    if (!elements.has(selector)) {
+      // A single object per selector doubles as both the element (waitFor/fill/
+      // click) and the chainable locator (filter/first/count/...).
+      const locator: any = {
+        waitFor: vi.fn().mockResolvedValue(undefined),
+        fill: vi.fn().mockResolvedValue(undefined),
+        click: vi.fn().mockResolvedValue(undefined),
+        // `.filter({ visible: true })` and `.first()` are chainable no-ops.
+        filter: vi.fn(() => locator),
+        first: () => locator,
+        // No device chooser is present in the unit-test DOM, so the `select`
+        // locator reports zero matches and device selection is skipped.
+        count: vi.fn(async () => (selector === 'select' ? 0 : 1)),
+        locator: vi.fn(() => makeLocator(`${selector} option`)),
+        allTextContents: vi.fn(async () => []),
+        textContent: vi.fn(async () => null),
+        selectOption: vi.fn().mockResolvedValue(undefined),
+      };
+      elements.set(selector, locator);
+    }
+    return elements.get(selector);
+  };
   const page = {
-    locator: vi.fn((selector: string) => ({
-      first: () => {
-        if (!elements.has(selector)) {
-          elements.set(selector, {
-            waitFor: vi.fn().mockResolvedValue(undefined),
-            fill: vi.fn().mockResolvedValue(undefined),
-            click: vi.fn().mockResolvedValue(undefined),
-          });
-        }
-        return elements.get(selector);
-      },
-    })),
+    locator: vi.fn((selector: string) => makeLocator(selector)),
     // Advance the fake clock so window arithmetic behaves like real time.
     waitForTimeout: vi.fn(async (ms: number) => {
       vi.advanceTimersByTime(ms);
@@ -117,6 +129,45 @@ describe('TotpChallengeHandler', () => {
     expect(elements.get(DEFAULT_TOTP_INPUT_SELECTOR).fill).toHaveBeenCalledWith(
       expectedTokenAt(MID_WINDOW_MS),
     );
+  });
+
+  it('selects the authenticator device before filling the code when a chooser is shown', async () => {
+    const elements = new Map<string, any>();
+    const selectMock = {
+      filter: vi.fn(() => selectMock),
+      first: () => selectMock,
+      count: vi.fn(async () => 1),
+      selectOption: vi.fn().mockResolvedValue(undefined),
+      locator: vi.fn((sub: string) => ({
+        allTextContents: vi.fn(async () => ['Select Type', 'IB Key', 'Mobile Authenticator App']),
+        first: () => ({ textContent: vi.fn(async () => (sub === 'option:checked' ? 'Select Type' : null)) }),
+      })),
+    };
+    const makeEl = () => ({
+      waitFor: vi.fn().mockResolvedValue(undefined),
+      fill: vi.fn().mockResolvedValue(undefined),
+      click: vi.fn().mockResolvedValue(undefined),
+    });
+    const page: any = {
+      locator: vi.fn((selector: string) => {
+        if (selector === 'select') return selectMock;
+        if (!elements.has(selector)) {
+          const el = makeEl();
+          elements.set(selector, { filter: vi.fn(() => ({ first: () => el })), first: () => el, _el: el });
+        }
+        return elements.get(selector);
+      }),
+      waitForTimeout: vi.fn(async (ms: number) => vi.advanceTimersByTime(ms)),
+    };
+
+    const handler = new TotpChallengeHandler({ secret: TEST_SECRET });
+    await expect(handler.submitCode(page)).resolves.toBe(true);
+
+    expect(selectMock.selectOption).toHaveBeenCalledWith({ label: 'Mobile Authenticator App' });
+    expect(elements.get(DEFAULT_TOTP_INPUT_SELECTOR)._el.fill).toHaveBeenCalledWith(
+      expectedTokenAt(MID_WINDOW_MS),
+    );
+    expect(elements.get(DEFAULT_TOTP_SUBMIT_SELECTOR)._el.click).toHaveBeenCalledTimes(1);
   });
 
   it('honors selector overrides for the input and submit controls', async () => {

--- a/test/headless-auth.test.ts
+++ b/test/headless-auth.test.ts
@@ -121,6 +121,27 @@ describe('TotpChallengeHandler', () => {
     expect(elements.get(DEFAULT_TOTP_INPUT_SELECTOR).fill).toHaveBeenCalledTimes(2);
   });
 
+  it('does not consume an attempt when the code input never appears', async () => {
+    const { page, elements } = createMockPage();
+    const handler = new TotpChallengeHandler({ secret: TEST_SECRET, maxAttempts: 2 });
+
+    // Simulate the security-code field never rendering. Instantiate the locator
+    // first (the mock creates elements lazily), then make waitFor reject.
+    const input = page.locator(DEFAULT_TOTP_INPUT_SELECTOR);
+    input.waitFor = vi.fn().mockRejectedValue(new Error('timeout'));
+
+    await expect(handler.submitCode(page)).rejects.toThrow('timeout');
+    // The attempt budget is untouched, so the caller can retry on a later poll
+    // instead of the handler locking itself out having never submitted a code.
+    expect(handler.exhausted).toBe(false);
+    expect(input.fill).not.toHaveBeenCalled();
+
+    // Once the field appears, a submission still succeeds within the same window.
+    input.waitFor = vi.fn().mockResolvedValue(undefined);
+    await expect(handler.submitCode(page)).resolves.toBe(true);
+    expect(input.fill).toHaveBeenCalledTimes(1);
+  });
+
   it('accepts base32 secrets containing spaces', async () => {
     const { page, elements } = createMockPage();
     const handler = new TotpChallengeHandler({ secret: 'MZXW 6YTB' });


### PR DESCRIPTION
## Problem

TOTP auto-login never completes for accounts that have **more than one 2FA device enrolled** (e.g. **IB Key** + **Mobile Authenticator App**). For those accounts IBKR inserts a **"Select Second Factor Device"** `<select>` chooser *before* the security-code field.

The handler classified this correctly as `method: 'factor_selection'` but had **no action for it** — TOTP only fired on `method: 'security_code'`, which never appears until a device is chosen. So the browser sat on the chooser until timeout and the REST API stayed at `401 Unauthorized`.

Two latent defects surfaced while fixing this:
- **Stale input selectors** — the real field on the current IBKR "XYZ" login widget is `#xyz-field-silver-response` (name `silver-response`, placeholder *"Mobile Authenticator App Code"*), not `#chg_response` / `#security_code`. Single-device accounts wouldn't have matched either.
- **`.first()` matched hidden nodes** — the credentials form leaves hidden login buttons/response inputs in the DOM, so an unscoped `.first()` could fill/click a hidden one.

## Fix

- **`totp-strategy.ts`** — new `selectAuthenticatorDevice()` picks the authenticator-app option in the chooser (idempotent no-op for single-device accounts); refreshed default input/submit selectors for current IBKR markup; visible-scoped the input & submit locators; new `deviceSelectSelector` option.
- **`headless-auth.ts`** — drive the TOTP handler on `factor_selection` as well as `security_code`; detect the "authenticator app code" screen; thread the new override.
- **`config.ts` / `tool-handlers.ts`** — new `IB_SELECTOR_TOTP_DEVICE_SELECT` override (joins the existing `IB_SELECTOR_TOTP_*` set).
- **tests** — added coverage for the device-chooser path; updated the page mock for the new locator chaining.

## Verification

- `npm test` → **200 passed**, 2 skipped.
- Exercised the built `HeadlessAuthenticator.authenticate()` against a live local Gateway: logs confirm it detects the chooser → selects "Mobile Authenticator App" → submits the TOTP, and the flow reaches `Client login succeeds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)