### PR TITLE
fix(auth): recover expired sessions instead of silently decaying

### DIFF
--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -44,6 +44,8 @@ export class IBClient {
   private maxAuthAttempts = 3;
   private tickleInterval?: NodeJS.Timeout;
   private tickleIntervalMs = 30000;
+  private tickleFailures = 0;
+  private maxTickleFailures = 10;
   private sessionCookieHeader?: string;
   private runtimeDir = path.join(__dirname, "../ib-gateway/.runtime");
   private ticklerJsonPath = path.join(this.runtimeDir, "tickler-session.json");
@@ -135,6 +137,11 @@ export class IBClient {
   private isStatusAuthenticated(status: unknown): boolean {
     if (!status || typeof status !== "object") return false;
     const s = status as AuthStatusResponse;
+    // A competing session means IBKR has handed the brokerage session to another
+    // client (phone app, web portal, a second gateway). The gateway keeps reporting
+    // established/authenticated, but requests against it fail. Treat it as unhealthy
+    // so recovery escalates instead of us trusting a session we no longer hold.
+    if (s.competing === true) return false;
     if (s.established === true) return true;
     return s.authenticated === true && s.connected !== false;
   }
@@ -188,20 +195,46 @@ export class IBClient {
 
       const authStatus = response.data?.iserver?.authStatus;
       if (authStatus && !this.isStatusAuthenticated(authStatus)) {
-        this.isAuthenticated = false;
-        this.stopTickle();
         Logger.warn("[TICKLE] Tickle returned unauthenticated status:", authStatus);
+        await this.recoverBrokerageSession();
         return;
       }
+      this.tickleFailures = 0;
       Logger.log("[TICKLE] Session maintenance ping sent successfully");
     } catch (error) {
-      Logger.warn("[TICKLE] Failed to send session maintenance ping:", error);
-      const isAuth = await this.checkAuthenticationStatus();
-      if (!isAuth) {
-        Logger.warn("[TICKLE] Session expired, stopping tickle interval");
+      // Connection refused, socket hang-up, gateway restarting, machine asleep: none
+      // of these mean the session is gone. Tolerate a run of them rather than tearing
+      // the loop down on the first blip and letting the session decay silently.
+      this.tickleFailures++;
+      Logger.warn(`[TICKLE] Session maintenance ping failed (${this.tickleFailures}/${this.maxTickleFailures}):`, error);
+      if (this.tickleFailures >= this.maxTickleFailures) {
+        Logger.warn("[TICKLE] Gateway unreachable for too long, stopping tickle interval");
+        this.isAuthenticated = false;
         this.stopTickle();
       }
     }
+  }
+
+  /**
+   * The brokerage session expires well before the SSO session does, so a plain
+   * reauthenticate is normally enough to bring it back - no browser, no 2FA, and no
+   * exposure to IBKR's login rate limits. Only give up once that fails, at which
+   * point the next tool call drives a full login.
+   */
+  private async recoverBrokerageSession(): Promise<void> {
+    try {
+      if (await this.initializeBrokerageSession()) {
+        this.tickleFailures = 0;
+        Logger.log("[TICKLE] Brokerage session recovered without a full login");
+        return;
+      }
+    } catch (error) {
+      Logger.warn("[TICKLE] Brokerage session recovery threw:", error);
+    }
+
+    Logger.warn("[TICKLE] Could not recover the brokerage session; a full login is required");
+    this.isAuthenticated = false;
+    this.stopTickle();
   }
 
   private startTickle(): void {

--- a/src/ib-client/types.ts
+++ b/src/ib-client/types.ts
@@ -4,6 +4,7 @@ export interface AuthStatusResponse {
   authenticated?: boolean;
   connected?: boolean;
   established?: boolean;
+  competing?: boolean;
   MAC?: string;
   hardware_info?: string;
 }

--- a/src/scripts/tickler.ts
+++ b/src/scripts/tickler.ts
@@ -6,6 +6,7 @@ interface AuthStatusResponse {
   established?: boolean;
   authenticated?: boolean;
   connected?: boolean;
+  competing?: boolean;
 }
 
 interface TickleResponse {
@@ -18,6 +19,17 @@ const args = process.argv.slice(2);
 const host = args[0] || "127.0.0.1";
 const port = Number(args[1]) || 5000;
 const sessionCookieHeader = process.env.IB_TICKLER_COOKIE_HEADER || "";
+
+/** Normal cadence. Also the ceiling for backoff: drifting past it risks the session. */
+const TICKLE_INTERVAL_MS = 30_000;
+/** First retry delay after a failure; doubles up to TICKLE_INTERVAL_MS. */
+const BASE_RETRY_MS = 5_000;
+/** Roughly 4 minutes of continuous failure before we hand back to the MCP server. */
+const MAX_CONSECUTIVE_FAILURES = 10;
+/** Cheap cookie-based reauth attempts before a full login (which we cannot do) is needed. */
+const MAX_REAUTH_ATTEMPTS = 3;
+/** Give the gateway a moment to settle after reauthenticate before re-reading status. */
+const REAUTH_SETTLE_MS = 1_000;
 
 const client = new HttpClient({
   baseUrl: `https://${host}:${port}/v1/api`,
@@ -33,12 +45,28 @@ if (sessionCookieHeader) {
   client.setHeader("Cookie", sessionCookieHeader);
 }
 
+let consecutiveFailures = 0;
+let reauthAttempts = 0;
+
+/** ok: session healthy. transient: retry later. terminal: only a full login can fix this. */
+type TickleOutcome = "ok" | "transient" | "terminal";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function isStatusAuthenticated(status: unknown): boolean {
   if (!status || typeof status !== "object") {
     return false;
   }
 
   const statusObj = status as AuthStatusResponse;
+  // A competing session means IBKR handed the brokerage session to another client.
+  // The gateway still reports it as established, but requests against it fail.
+  if (statusObj.competing === true) {
+    return false;
+  }
+
   if (statusObj.established === true) {
     return true;
   }
@@ -51,7 +79,49 @@ async function request<T>(method: string, path: string): Promise<T> {
   return response.data;
 }
 
-async function checkAndTickle(): Promise<boolean> {
+/**
+ * The brokerage session dies long before the SSO session does, so a plain
+ * reauthenticate usually revives it using the cookies we already hold - no browser
+ * and no 2FA. This tickler has no credentials, so this is the only recovery it can
+ * perform; anything beyond it has to be escalated to the MCP server.
+ */
+async function attemptReauthenticate(): Promise<boolean> {
+  try {
+    await request("POST", "/iserver/reauthenticate");
+    await sleep(REAUTH_SETTLE_MS);
+    const status = await request<AuthStatusResponse>("GET", "/iserver/auth/status");
+    return isStatusAuthenticated(status);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("[TICKLER] Reauthenticate request failed:", message);
+    return false;
+  }
+}
+
+async function recoverSession(): Promise<TickleOutcome> {
+  reauthAttempts++;
+
+  if (await attemptReauthenticate()) {
+    console.log("[TICKLER] Reauthenticate restored the brokerage session");
+    reauthAttempts = 0;
+    return "ok";
+  }
+
+  if (reauthAttempts >= MAX_REAUTH_ATTEMPTS) {
+    console.log(
+      `[TICKLER] Reauthenticate exhausted after ${reauthAttempts} attempts. ` +
+        "A full login with 2FA is required, which this process cannot perform. Self-terminating.",
+    );
+    return "terminal";
+  }
+
+  console.warn(
+    `[TICKLER] Reauthenticate attempt ${reauthAttempts}/${MAX_REAUTH_ATTEMPTS} did not restore the session; will retry`,
+  );
+  return "transient";
+}
+
+async function checkAndTickle(): Promise<TickleOutcome> {
   try {
     let tickleResponse: TickleResponse;
 
@@ -65,43 +135,64 @@ async function checkAndTickle(): Promise<boolean> {
       }
     }
 
-    const authStatus = tickleResponse.iserver?.authStatus;
-    if (!isStatusAuthenticated(authStatus)) {
-      console.log("[TICKLER] Session no longer authenticated. Self-terminating.");
-      return false;
+    if (isStatusAuthenticated(tickleResponse.iserver?.authStatus)) {
+      console.log("[TICKLER] Session tickled and authentication verified successfully");
+      reauthAttempts = 0;
+      return "ok";
     }
 
-    console.log("[TICKLER] Session tickled and authentication verified successfully");
-    return true;
+    console.log("[TICKLER] Brokerage session is not authenticated; attempting reauthenticate");
+    return await recoverSession();
   } catch (error) {
     if (error instanceof HttpError && error.response.status === 401) {
-      console.log("[TICKLER] HTTP 401 Unauthorized encountered. Self-terminating.");
-      return false;
+      console.log("[TICKLER] HTTP 401 Unauthorized; attempting reauthenticate");
+      return await recoverSession();
     }
 
+    // Connection refused, socket hang-up, gateway restarting, machine asleep. None of
+    // these mean the session is gone, so stay alive and retry: exiting here is what
+    // silently let the session decay overnight.
     const message = error instanceof Error ? error.message : String(error);
-    console.error("[TICKLER] Connection/request error:", message);
-    console.log("[TICKLER] Gateway unreachable or network error. Self-terminating.");
-    return false;
+    console.error("[TICKLER] Transient connection/request error:", message);
+    return "transient";
   }
+}
+
+function nextDelayMs(failures: number): number {
+  if (failures === 0) {
+    return TICKLE_INTERVAL_MS;
+  }
+  // Back off on repeated failure, but never past the normal cadence: the session
+  // needs tickling on time even while we are struggling to reach the gateway.
+  return Math.min(TICKLE_INTERVAL_MS, BASE_RETRY_MS * 2 ** (failures - 1));
 }
 
 async function run(): Promise<void> {
   console.log(`[TICKLER] Persistent session tickler started for ${host}:${port} (PID: ${process.pid})`);
 
-  const ok = await checkAndTickle();
-  if (!ok) {
-    process.exit(0);
-  }
+  for (;;) {
+    const outcome = await checkAndTickle();
 
-  const interval = setInterval(async () => {
-    const stillOk = await checkAndTickle();
-    if (!stillOk) {
-      clearInterval(interval);
+    if (outcome === "terminal") {
       console.log("[TICKLER] Terminating ticker loop.");
       process.exit(0);
     }
-  }, 30000);
+
+    if (outcome === "ok") {
+      consecutiveFailures = 0;
+    } else {
+      consecutiveFailures++;
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        console.error(
+          `[TICKLER] ${consecutiveFailures} consecutive failures; the gateway looks unreachable. ` +
+            "Self-terminating; the MCP server will respawn a tickler on the next authenticated call.",
+        );
+        process.exit(0);
+      }
+    }
+
+    await sleep(nextDelayMs(consecutiveFailures));
+  }
 }
 
 run().catch((err) => {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -55,8 +55,15 @@ type HeadlessAuthOutcome = {
 const DEFAULT_AUTH_WAIT_SECONDS = 60;
 const DEFAULT_AUTH_POLL_SECONDS = 5;
 
+/**
+ * IBKR rate-limits rapid logins and will lock an account that keeps retrying. Without
+ * this ceiling a broken login drives a fresh browser session on every tool call.
+ */
+const MAX_FAILED_LOGINS = 5;
+
 export class ToolHandlers {
   private context: ToolHandlerContext;
+  private failedLogins = 0;
 
   constructor(context: ToolHandlerContext) {
     this.context = context;
@@ -160,6 +167,15 @@ export class ToolHandlers {
       return { ok: true };
     }
 
+    // The brokerage session expires long before the SSO session does, so a plain
+    // reauthenticate normally revives it - no browser, no 2FA, and no exposure to
+    // IBKR's login rate limits. Try that before paying for a full login. This is the
+    // cheap rung of the ladder and it works in browser mode too, where the only other
+    // option is to make the user go and click through a login page.
+    if (await this.tryReauthenticate()) {
+      return { ok: true };
+    }
+
     // If not authenticated, and not in headless mode, throw an error immediately.
     if (!this.context.config.IB_HEADLESS_MODE) {
       const authUrl = this.buildAuthUrl();
@@ -180,6 +196,21 @@ export class ToolHandlers {
       };
     }
     
+    // Stop hammering IBKR once a login is clearly not going to succeed: retrying on
+    // every tool call is how an account ends up rate-limited or locked out.
+    if (this.failedLogins >= MAX_FAILED_LOGINS) {
+      return {
+        ok: false,
+        result: this.jsonResult({
+          success: false,
+          status: "AUTHENTICATION_CIRCUIT_OPEN",
+          message: `Headless authentication failed ${this.failedLogins} times in a row. Refusing to retry automatically to avoid IBKR rate-limiting or an account lockout.`,
+          nextInstruction:
+            "Check IB_USERNAME, IB_PASSWORD_AUTH and IB_TOTP_SECRET, then call the 'authenticate' tool to reset the circuit and retry.",
+        }),
+      };
+    }
+
     // Configuration for the polling loop
     const timeoutSeconds = this.context.config.IB_AUTH_TIMEOUT || 300; // 5 minutes default
     const pollIntervalSeconds = 5;
@@ -212,28 +243,83 @@ export class ToolHandlers {
       isAuthenticated = await this.context.ibClient.checkAuthenticationStatus();
       if (isAuthenticated) {
         Logger.info("✅ Authentication successful.");
+        this.failedLogins = 0;
         return { ok: true };
       }
       await this.sleep(pollIntervalSeconds * 1000);
     }
 
     // If the loop completes without success, we've timed out
-    Logger.error(`❌ Authentication timed out after ${timeoutSeconds} seconds.`);
+    this.failedLogins++;
+    Logger.error(`❌ Authentication timed out after ${timeoutSeconds} seconds (failure ${this.failedLogins}/${MAX_FAILED_LOGINS}).`);
     throw new Error(`Authentication timed out after ${timeoutSeconds} seconds. Please check for a 2FA notification on your device.`);
+  }
+
+  /**
+   * Cheapest rung of the recovery ladder: a plain reauthenticate against the gateway,
+   * reusing the SSO session we still hold. Costs one HTTP round trip and, unlike a full
+   * login, involves no browser, no 2FA and no login rate limit.
+   */
+  private async tryReauthenticate(): Promise<boolean> {
+    try {
+      Logger.info("Brokerage session is not authenticated; attempting reauthenticate before a full login.");
+      await this.context.ibClient.reauthenticate();
+      const recovered = await this.context.ibClient.checkAuthenticationStatus();
+      if (recovered) {
+        Logger.info("✅ Reauthenticate restored the brokerage session; skipping full login.");
+        this.failedLogins = 0;
+      } else {
+        Logger.info("Reauthenticate did not restore the session; a full login is required.");
+      }
+      return recovered;
+    } catch (error) {
+      Logger.warn("Reauthenticate failed; falling back to a full login:", error);
+      return false;
+    }
+  }
+
+  /**
+   * Transport failures that mean "the connection died", not "the request was rejected".
+   * A dropped socket to the gateway is recoverable by re-establishing the session, so it
+   * has to be classified as an auth error - otherwise it surfaces raw to the caller and
+   * the recovery path in ensureAuth never runs.
+   */
+  private isTransportError(error: any): boolean {
+    const code = error?.code || error?.cause?.code;
+    if (
+      code === "ECONNRESET" ||
+      code === "EPIPE" ||
+      code === "ECONNREFUSED" ||
+      code === "ETIMEDOUT" ||
+      code === "ENOTFOUND" ||
+      code === "UND_ERR_SOCKET" ||
+      code === "UND_ERR_CONNECT_TIMEOUT"
+    ) {
+      return true;
+    }
+
+    const message = String(error?.message || "");
+    return (
+      message.includes("stream was destroyed") ||
+      message.includes("socket hang up") ||
+      message.includes("other side closed") ||
+      message.includes("fetch failed")
+    );
   }
 
   // Helper function to check for authentication errors
   private isAuthenticationError(error: any): boolean {
     if (!error) return false;
-    
+
     const errorMessage = error.message || error.toString();
     const errorStatus = error.response?.status;
     const responseData = error.response?.data;
-    
+
     return (
       errorStatus === 401 ||
       errorStatus === 403 ||
       errorStatus === 500 ||
+      this.isTransportError(error) ||
       errorMessage.includes("authentication") ||
       errorMessage.includes("unauthorized") ||
       errorMessage.includes("not authenticated") ||
@@ -310,9 +396,13 @@ export class ToolHandlers {
 
   async authenticate(input: AuthenticateInput): Promise<ToolHandlerResult> {
     try {
+      // An explicit authenticate call is the caller asserting they have fixed whatever
+      // was broken, so it resets the circuit breaker that ensureAuth may have opened.
+      this.failedLogins = 0;
+
       // Ensure Gateway is ready
       await this.ensureGatewayReady();
-      
+
       const port = this.context.gatewayManager 
         ? this.context.gatewayManager.getCurrentPort() 
         : this.context.config.IB_GATEWAY_PORT;

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -106,6 +106,18 @@ describe('IBClient', () => {
       expect(result).toBe(false);
     });
 
+    it('should treat a competing session as unauthenticated', async () => {
+      // IBKR handed the brokerage session to another client. The gateway still reports it
+      // as established, but every request against it will fail.
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({ authenticated: true, connected: true, established: true, competing: true })
+      );
+
+      const result = await client.checkAuthenticationStatus();
+
+      expect(result).toBe(false);
+    });
+
     it('should spawn the durable tickler with package-anchored paths and env cookies', () => {
       client.setSessionCookies([{ name: 'SBID', value: 'abc', domain: 'localhost' }]);
 

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -365,6 +365,44 @@ describe('ToolHandlers', () => {
       expect(HeadlessAuthenticator).not.toHaveBeenCalled();
     });
 
+    it('should recover an expired session via reauthenticate without a browser or 2FA', async () => {
+      const mockAccounts = [{ id: 'U12345' }];
+      mockIBClient.getAccountInfo = vi.fn().mockResolvedValue({ accounts: mockAccounts });
+      mockIBClient.reauthenticate = vi.fn();
+
+      // The brokerage session is dead but SSO is still valid, so reauthenticate revives it.
+      vi.mocked(mockIBClient.checkAuthenticationStatus)
+        .mockResolvedValueOnce(false) // ensureAuth's initial check
+        .mockResolvedValueOnce(true);  // after reauthenticate
+
+      const result = await handlers.getAccountInfo({ confirm: true });
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.accounts).toEqual(mockAccounts);
+      expect(mockIBClient.reauthenticate).toHaveBeenCalledTimes(1);
+      // The whole point: no headless login, so no TOTP and no IBKR login rate limit.
+      expect(HeadlessAuthenticator).not.toHaveBeenCalled();
+    });
+
+    it('should open the circuit breaker after repeated login failures', async () => {
+      vi.useFakeTimers();
+      vi.mocked(mockIBClient.checkAuthenticationStatus).mockResolvedValue(false);
+      mockIBClient.reauthenticate = vi.fn();
+
+      for (let i = 0; i < 5; i++) {
+        const attempt = (handlers as any).ensureAuth();
+        attempt.catch(() => {}); // avoid an unhandled rejection while we advance timers
+        await vi.advanceTimersByTimeAsync(11 * 1000);
+        await expect(attempt).rejects.toThrow(/Authentication timed out/);
+      }
+
+      // The sixth attempt must refuse to touch IBKR again rather than risk a lockout.
+      const guarded = await (handlers as any).ensureAuth();
+      expect(guarded.ok).toBe(false);
+      expect(JSON.parse(guarded.result.content[0].text).status).toBe('AUTHENTICATION_CIRCUIT_OPEN');
+      expect(HeadlessAuthenticator).toHaveBeenCalledTimes(5);
+    });
+
     it('should block, authenticate, and then return account info', async () => {
       vi.useFakeTimers();
       const mockAccounts = [{ id: 'U12345' }];
@@ -435,7 +473,7 @@ describe('ToolHandlers', () => {
       expect(mockIBClient.reauthenticate).not.toHaveBeenCalled();
     });
 
-    it('should throw when not authenticated on both checks', async () => {
+    it('should attempt reauthenticate before giving up, and throw when it does not help', async () => {
       mockIBClient.checkAuthenticationStatus = vi.fn()
         .mockResolvedValueOnce(false)
         .mockResolvedValueOnce(false);
@@ -443,7 +481,17 @@ describe('ToolHandlers', () => {
 
       await expect((handlers as any).ensureAuth())
         .rejects.toThrow('Authentication required');
-      expect(mockIBClient.reauthenticate).not.toHaveBeenCalled();
+      expect(mockIBClient.reauthenticate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should recover via reauthenticate without forcing a manual browser login', async () => {
+      mockIBClient.checkAuthenticationStatus = vi.fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+      mockIBClient.reauthenticate = vi.fn();
+
+      await expect((handlers as any).ensureAuth()).resolves.toEqual({ ok: true });
+      expect(mockIBClient.reauthenticate).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## The bug

Users report that once the IBKR session expires, auth "doesn't work properly" and only a restart fixes it. The production logs on a live install show exactly why.

Counting `/tickle` calls against the Gateway's own `/sso/ping` in `gw.2026-07-13.log`:

```
  hour 00 -> tickle=0   sso_ping=12
  hour 01 -> tickle=0   sso_ping=12
  ...
  hour 08 -> tickle=0   sso_ping=12
  hour 09 -> tickle=53  sso_ping=8     <- after a manual restart
```

**Zero tickles all night, and zero the previous day.** The Gateway's internal `/sso/ping` kept returning `200 {"result":"true"}` every 5 minutes, so the **SSO** layer stayed alive — but nothing was calling `/tickle`, so the **iserver brokerage session** was never maintained. That's the session that was dead the next morning.

### Why the tickler wasn't running

`src/scripts/tickler.ts` treated *any* error as fatal:

```ts
console.log("[TICKLER] Gateway unreachable or network error. Self-terminating.");
return false;   // -> process.exit(0)
```

One transient blip — a Gateway hiccup, a laptop suspend — and the tickler exits **permanently**. Nothing respawns it: `spawnDurableTickler()` is only reachable from `startTickle()`, which only runs after a successful auth check inside the MCP process.

### Why recovery was more expensive than necessary

`ensureAuth()` jumped straight from "not authenticated" to a **full headless browser + TOTP login**. But the logs show SSO was healthy the entire time — only the brokerage session was dead. A single `POST /iserver/reauthenticate` would have restored it: no browser, no 2FA, no exposure to IBKR's login rate limits (the ones we already hit in #73).

`reauthenticate()` already existed in `ib-client.ts` — it was just never wired into session death.

## The fix

A recovery **ladder**, cheapest rung first: `tickle → POST /iserver/reauthenticate → full login`.

- **Tickler no longer self-terminates on transient errors.** Outcomes are classified `ok` / `transient` / `terminal`. Transient errors retry with backoff (5s→10s→20s, capped at the 30s cadence so the session never goes untickled). It exits only after sustained failure, and the MCP server respawns it on the next authenticated call. It can also perform the cheap reauth rung itself (it holds cookies, so no credentials needed).
- **Cheap rung tried before a full login**, in both headless *and* browser mode — browser-mode users previously had no recovery at all and had to go click through a login page.
- **`competing` is no longer ignored.** `grep -rn "competing" src/` previously returned zero hits, while `established: true` sits right beside it in the real payload and was trusted unconditionally. So a session IBKR had handed to another client (phone, web portal) was reported healthy and then failed on the next call.
- **Circuit breaker** after 5 consecutive failed logins → `AUTHENTICATION_CIRCUIT_OPEN` instead of firing a fresh browser login on every tool call. Directly targets the IBKR rate-limiting from #73. An explicit `authenticate` call resets it.
- **Transport errors** (`ECONNRESET`/`EPIPE`/`socket hang up`/`stream was destroyed`) are now classified as auth-recoverable, so they enter the ladder instead of surfacing raw. Previously `isAuthenticationError()` only matched 401/403/500, so a dropped socket never triggered recovery.

## Scope: no gateway process control

Deliberately excluded. v2 (#74) adopts a gateway it did not start (`findExistingGateway()`) and explicitly never kills it (`"Don't kill gateway - just clean references"`). Restarting the Gateway is IBeam's top recovery rung, but IBeam earns it by vendoring the gateway and shipping it in its own container — it owns the process outright. We don't, so **recovery stays entirely at the HTTP session layer** and terminates in circuit-break-and-report rather than restart.

## Verification

- `npm run build` ✅ · `oxlint` ✅ (warnings only, matches baseline) · **205 tests pass**, 4 new (competing-session, reauth-recovery-without-browser, browser-mode recovery, circuit breaker)
- One existing test updated: it asserted `reauthenticate` is *not* called in browser mode — that assertion encoded the bug.
- **New tickler vs. unreachable gateway:** retried 3× with backoff over 22s and never self-terminated. The old code exited on the first error.
- **New tickler vs. a live gateway:** tickled successfully at 30s cadence, still looping.
- **Live gateway `/iserver/auth/status`** confirms `competing` is a real field, returned alongside `established: true`.

## Follow-up (not in this PR)

`ib-client.ts`'s `runtimeDir` still points at `path.join(__dirname, "../ib-gateway/.runtime")` — inside `node_modules`. v2 moves Gateway state to `<cache>/run/` via `DependencyResolver.runDir()` but does not migrate the tickler's PID file. Post-v2 the npx cache dir is content-hashed, so a version bump orphans the PID file and `spawnDurableTickler()` will spawn duplicates. One-line fix, but it belongs in #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)