### PR TITLE
Harden live order safety and add account-scoped cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ confirmation attempt and exact broker response is durably appended to the same
 client-order record, allowing multi-step warnings to continue after a restart.
 Unknown, foreign-account, ambiguous, legacy, and already-attempted reply IDs
 fail closed; an uncertain confirmation must be reconciled manually rather than
-repeated automatically.
+repeated automatically. Warning `messageIds` are taken from that same persisted
+broker response. A caller may omit them; when supplied for compatibility, their
+set must match the persisted warning exactly (ordering is ignored).
 
 Every HTTP failure returned while submitting an order is reported as an
 uncertain submission outcome. The server will not automatically retry that

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ your IB account to retrieve market data, check positions, and place trades.
 
 ## Features
 
-- **Interactive Brokers API Integration**: Full trading capabilities including account management, position tracking, real-time market data, and order management (market, limit, and stop orders)
+- **Interactive Brokers API Integration**: Account management, position tracking, real-time market data, and guarded limit-stock order placement
 - **Flex Query Support**: Execute Flex Queries to retrieve account statements, trade confirmations, and historical data. Queries are automatically remembered for easy reuse
 - **Flexible Authentication**: Choose between browser-based OAuth authentication or headless mode with credentials for automated environments, including fully automated TOTP 2FA override. See [TOTP 2FA Strategy Document](docs/2FA-TOTP-STRATEGY.md) for detailed configuration and important risk warnings.
 - **Simple Setup**: Run directly with `npx` - no Docker or additional installations required. Includes pre-configured IB Gateway and Java runtime for all platforms
@@ -192,12 +192,21 @@ For a complete guide on creating and customizing Flex Queries, see the [IB Flex 
 | Force standalone bundled gateway | `IB_FORCE_STANDALONE_GATEWAY` | N/A |
 | Flex Token | `IB_FLEX_TOKEN` | N/A |
 | Read-only mode | `IB_READ_ONLY_MODE` | `--ib-read-only-mode` |
+| Allowed live-write account | `IB_ALLOWED_ACCOUNT_ID` | `--ib-allowed-account-id` |
 | 2FA Strategy | `IB_TWO_FA_STRATEGY` | N/A |
 | TOTP Secret Key | `IB_TOTP_SECRET` | N/A |
 | Login page selector overrides | `IB_SELECTOR_USERNAME`, `IB_SELECTOR_PASSWORD`, `IB_SELECTOR_LOGIN_SUBMIT` | N/A |
 | TOTP form selector overrides | `IB_SELECTOR_TOTP_INPUT`, `IB_SELECTOR_TOTP_SUBMIT` | N/A |
 
 See the [TOTP 2FA Strategy Document](docs/2FA-TOTP-STRATEGY.md) for details on the 2FA and selector-override variables.
+
+The server is read-only by default. Live write tools are registered only when
+`IB_READ_ONLY_MODE=false` is set explicitly and `IB_ALLOWED_ACCOUNT_ID` names
+the single account permitted for writes. `place_order` accepts limit (`LMT`)
+stock orders only; market, stop, and option orders are rejected. Every order
+must provide a unique `clientOrderId`, a positive finite quantity and price,
+and either a symbol or conid that IBKR resolves unambiguously to a `STK`
+contract.
 
 ## Gateway Lifecycle
 
@@ -222,7 +231,7 @@ To reset the managed Gateway session, stop the Gateway process recorded in `ib-g
 | `get_account_info` | Retrieve account information and balances |
 | `get_positions`    | Get current positions and P&L             |
 | `get_market_data`  | Real-time market data for symbols         |
-| `place_order`      | Place market, limit, or stop orders (only if read-only mode is disabled) |
+| `place_order`      | Place limit stock orders for the allowlisted account (only when live writes are explicitly enabled) |
 | `get_order_status` | Check order execution status              |
 | `get_live_orders`  | Get all live/open orders for monitoring   |
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ When you first use the server, a web browser window will automatically open for
 the Interactive Brokers OAuth authentication flow. Log in with your IB
 credentials to authorize the connection.
 
+Browser authentication is recommended for local use because it avoids placing
+your IBKR password or 2FA secret in the MCP process configuration. Headless
+credentials remain available for environments that explicitly require them,
+but they increase the impact of a compromised host or configuration file.
+
 ## Headless Mode Configuration
 
 For automated environments or when you prefer not to use a browser for
@@ -208,6 +213,18 @@ must provide a unique `clientOrderId`, a positive finite quantity and price,
 and either a symbol or conid that IBKR resolves unambiguously to a `STK`
 contract.
 
+Every HTTP failure returned while submitting an order is reported as an
+uncertain submission outcome. The server will not automatically retry that
+`clientOrderId`; check IBKR live orders and executions manually before taking
+another action. Broker warnings are not auto-confirmed. Review them and invoke
+`confirm_order` explicitly only when the warning is understood.
+
+`cancel_order` is exposed under the same live-write conditions: explicit
+`IB_READ_ONLY_MODE=false` and a configured `IB_ALLOWED_ACCOUNT_ID`. Its
+`accountId` must match that single allowlisted account. Cancellation does not
+use the order-submission `clientOrderId` idempotency mechanism; verify the raw
+broker response and then check `get_live_orders` to confirm the final state.
+
 ## Gateway Lifecycle
 
 On startup, the MCP first probes reachable local Gateway endpoints on the configured port and common Client Portal Gateway ports. If a healthy existing Gateway is found, the MCP attaches to it and does not start another bundled Gateway.
@@ -232,6 +249,8 @@ To reset the managed Gateway session, stop the Gateway process recorded in `ib-g
 | `get_positions`    | Get current positions and P&L             |
 | `get_market_data`  | Real-time market data for symbols         |
 | `place_order`      | Place limit stock orders for the allowlisted account (only when live writes are explicitly enabled) |
+| `confirm_order`    | Manually confirm a broker warning (only when live writes are explicitly enabled) |
+| `cancel_order`     | Cancel an order for the allowlisted account and return the raw broker response (only when live writes are explicitly enabled) |
 | `get_order_status` | Check order execution status              |
 | `get_live_orders`  | Get all live/open orders for monitoring   |
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,13 @@ For a complete guide on creating and customizing Flex Queries, see the [IB Flex 
 
 See the [TOTP 2FA Strategy Document](docs/2FA-TOTP-STRATEGY.md) for details on the 2FA and selector-override variables.
 
+Both `--flag value` and `--flag=value` CLI forms are supported. Current
+versions redact usernames, passwords, TOTP secrets, and Flex tokens before
+logging command-line or merged configuration data. Older releases logged raw
+command-line arguments; after upgrading, delete or rotate
+`~/.ib-mcp/ib-mcp.log` (or the log under `IB_MCP_LOG_DIR`) if credentials were
+ever supplied on the command line.
+
 The server is read-only by default. Live write tools are registered only when
 `IB_READ_ONLY_MODE=false` is set explicitly and `IB_ALLOWED_ACCOUNT_ID` names
 the single account permitted for writes. `place_order` accepts limit (`LMT`)
@@ -212,6 +219,14 @@ stock orders only; market, stop, and option orders are rejected. Every order
 must provide a unique `clientOrderId`, a positive finite quantity and price,
 and either a symbol or conid that IBKR resolves unambiguously to a `STK`
 contract.
+
+`confirm_order` accepts only an exact IBKR warning reply ID previously returned
+by this MCP's persisted `place_order` chain for the allowlisted account. Each
+confirmation attempt and exact broker response is durably appended to the same
+client-order record, allowing multi-step warnings to continue after a restart.
+Unknown, foreign-account, ambiguous, legacy, and already-attempted reply IDs
+fail closed; an uncertain confirmation must be reconciled manually rather than
+repeated automatically.
 
 Every HTTP failure returned while submitting an order is reported as an
 uncertain submission outcome. The server will not automatically retry that

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,0 +1,114 @@
+import { parseReadOnlyMode } from "./config.js";
+import { Logger } from "./logger.js";
+
+const REDACTED = "[REDACTED]";
+const SENSITIVE_CLI_FLAGS = new Set([
+  "ib-username",
+  "ib-password",
+  "ib-password-auth",
+  "ib-totp-secret",
+  "ib-flex-token",
+]);
+
+function normalizeFlag(flag: string): string {
+  return flag.replace(/^--/, "").split("=", 1)[0].toLowerCase();
+}
+
+function isSensitiveFlag(flag: string): boolean {
+  const normalized = normalizeFlag(flag);
+  return SENSITIVE_CLI_FLAGS.has(normalized)
+    || /(?:username|password|totp|secret|token|credential|cookie)/i.test(normalized);
+}
+
+export function sanitizeCliArguments(argv: readonly string[]): string[] {
+  const sanitized: string[] = [];
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    const equals = arg.indexOf("=");
+    const flag = equals >= 0 ? arg.slice(0, equals) : arg;
+    if (!flag.startsWith("--") || !isSensitiveFlag(flag)) {
+      sanitized.push(arg);
+      continue;
+    }
+    if (equals >= 0) {
+      sanitized.push(`${flag}=${REDACTED}`);
+      continue;
+    }
+    sanitized.push(flag);
+    if (index + 1 < argv.length && !argv[index + 1].startsWith("--")) {
+      sanitized.push(REDACTED);
+      index++;
+    }
+  }
+  return sanitized;
+}
+
+export function redactConfigForLogging<T extends Record<string, unknown>>(config: T): T {
+  const seen = new WeakSet<object>();
+  const redact = (value: unknown, key = ""): unknown => {
+    if (/(?:USERNAME|PASSWORD|TOTP|SECRET|TOKEN|CREDENTIAL|COOKIE)/i.test(key) && value) {
+      return REDACTED;
+    }
+    if (!value || typeof value !== "object") return value;
+    if (seen.has(value)) return "[CIRCULAR]";
+    seen.add(value);
+    if (Array.isArray(value)) return value.map((entry) => redact(entry));
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([entryKey, entry]) => [
+        entryKey,
+        redact(entry, entryKey),
+      ]),
+    );
+  };
+  return redact(config) as T;
+}
+
+const STRING_FLAGS: Record<string, string> = {
+  "ib-username": "IB_USERNAME",
+  "ib-password": "IB_PASSWORD_AUTH",
+  "ib-password-auth": "IB_PASSWORD_AUTH",
+  "ib-totp-secret": "IB_TOTP_SECRET",
+  "ib-flex-token": "IB_FLEX_TOKEN",
+  "ib-allowed-account-id": "IB_ALLOWED_ACCOUNT_ID",
+};
+
+const NUMBER_FLAGS: Record<string, string> = {
+  "ib-auth-timeout": "IB_AUTH_TIMEOUT",
+  "ib-auth-wait-seconds": "IB_AUTH_WAIT_SECONDS",
+  "ib-auth-poll-seconds": "IB_AUTH_POLL_SECONDS",
+};
+
+const BOOLEAN_FLAGS: Record<string, string> = {
+  "ib-headless-mode": "IB_HEADLESS_MODE",
+  "ib-paper-trading": "IB_PAPER_TRADING",
+};
+
+export function parseCliArgs(argv: readonly string[] = process.argv.slice(2)): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  Logger.info(`🔍 Sanitized command line arguments: ${JSON.stringify(sanitizeCliArguments(argv))}`);
+
+  for (let index = 0; index < argv.length; index++) {
+    const raw = argv[index];
+    if (!raw.startsWith("--")) continue;
+    const equals = raw.indexOf("=");
+    const key = raw.slice(2, equals >= 0 ? equals : undefined);
+    let value = equals >= 0 ? raw.slice(equals + 1) : undefined;
+    if (value === undefined && argv[index + 1] && !argv[index + 1].startsWith("--")) {
+      value = argv[++index];
+    }
+    Logger.debug(`🔍 Processing CLI flag: ${key}${isSensitiveFlag(key) ? " [REDACTED]" : ""}`);
+
+    if (STRING_FLAGS[key]) {
+      if (value !== undefined) args[STRING_FLAGS[key]] = value;
+    } else if (NUMBER_FLAGS[key]) {
+      if (value !== undefined) args[NUMBER_FLAGS[key]] = Number.parseInt(value, 10);
+    } else if (BOOLEAN_FLAGS[key]) {
+      args[BOOLEAN_FLAGS[key]] = value === undefined ? true : value.toLowerCase() === "true";
+    } else if (key === "ib-read-only-mode") {
+      args.IB_READ_ONLY_MODE = value === undefined ? true : parseReadOnlyMode(value);
+    }
+  }
+
+  Logger.info(`🔍 Parsed args: ${JSON.stringify(redactConfigForLogging(args), null, 2)}`);
+  return args;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,10 @@ import { config as dotenvConfig } from "dotenv";
 // Load environment variables
 dotenvConfig();
 
+export function parseReadOnlyMode(value: unknown): boolean {
+  return value !== false && value !== "false";
+}
+
 export const config = {
   IB_GATEWAY_HOST: process.env.IB_GATEWAY_HOST || "localhost",
   IB_GATEWAY_PORT: parseInt(process.env.IB_GATEWAY_PORT || "5000"),
@@ -22,7 +26,8 @@ export const config = {
   IB_PAPER_TRADING: process.env.IB_PAPER_TRADING === "true",
 
   // Read-only mode configuration
-  IB_READ_ONLY_MODE: process.env.IB_READ_ONLY_MODE === "true",
+  IB_READ_ONLY_MODE: parseReadOnlyMode(process.env.IB_READ_ONLY_MODE),
+  IB_ALLOWED_ACCOUNT_ID: process.env.IB_ALLOWED_ACCOUNT_ID?.trim() || undefined,
 
   // 2FA TOTP configuration
   IB_TWO_FA_STRATEGY: process.env.IB_TWO_FA_STRATEGY || "manual",

--- a/src/headless-auth.ts
+++ b/src/headless-auth.ts
@@ -1,5 +1,6 @@
 import { chromium, Browser, Page } from 'playwright-core';
 import { Logger } from './logger.js';
+import { redactConfigForLogging } from './cli-args.js';
 import { IBClient } from './ib-client.js';
 import { BrowserInstaller } from './browser-installer.js';
 import { TotpChallengeHandler } from './totp-strategy.js';
@@ -72,8 +73,7 @@ export class HeadlessAuthenticator {
       Logger.info('🔐 Starting headless authentication...');
       
       // Log the full auth config for debugging (excluding sensitive data)
-      const logConfig = { ...authConfig };
-      if (logConfig.password) logConfig.password = '[REDACTED]';
+      const logConfig = redactConfigForLogging({ ...authConfig });
       Logger.info(`🔍 Authentication config: ${JSON.stringify(logConfig, null, 2)}`);
       
       // Use local browser - let Playwright handle everything

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -14,7 +14,16 @@ import {
 import { getAccountInfo, getPositions } from "./ib-client/accounts.js";
 import { getMarketData } from "./ib-client/market-data.js";
 import { getOptionChain, resolveOptionConid } from "./ib-client/options.js";
-import { placeOrder, confirmOrder, getOrderStatus, getOrders, OrderSubmissionError } from "./ib-client/orders.js";
+import {
+  placeOrder,
+  prepareOrder,
+  submitPreparedOrder,
+  confirmOrder,
+  getOrderStatus,
+  getOrders,
+  OrderSubmissionError,
+  type PreparedOrder,
+} from "./ib-client/orders.js";
 import { getAlerts, createAlert, activateAlert, deleteAlert } from "./ib-client/alerts.js";
 import {
   type AuthStatusResponse,
@@ -540,6 +549,14 @@ export class IBClient {
 
   async placeOrder(orderRequest: OrderRequest): Promise<unknown> {
     return placeOrder(this, orderRequest);
+  }
+
+  async prepareOrder(orderRequest: OrderRequest): Promise<PreparedOrder> {
+    return prepareOrder(this, orderRequest);
+  }
+
+  async submitPreparedOrder(prepared: PreparedOrder): Promise<unknown> {
+    return submitPreparedOrder(this, prepared);
   }
 
   async confirmOrder(replyId: string, messageIds: string[]): Promise<unknown> {

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -24,12 +24,13 @@ import {
   type OrderRequest,
   type TickleResponse,
   SymbolNotFoundError,
+  InvalidOrderContractError,
 } from "./ib-client/types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TICKLER_COOKIE_ENV = "IB_TICKLER_COOKIE_HEADER";
 
-export { SymbolNotFoundError };
+export { SymbolNotFoundError, InvalidOrderContractError };
 
 // ---------------------------------------------------------------------------
 // Client

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -23,6 +23,7 @@ import {
   getOrderStatus,
   getOrders,
   OrderSubmissionError,
+  OrderConfirmationError,
   OrderCancellationError,
   type PreparedOrder,
 } from "./ib-client/orders.js";
@@ -41,7 +42,7 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TICKLER_COOKIE_ENV = "IB_TICKLER_COOKIE_HEADER";
 
-export { SymbolNotFoundError, InvalidOrderContractError, OrderSubmissionError, OrderCancellationError };
+export { SymbolNotFoundError, InvalidOrderContractError, OrderSubmissionError, OrderConfirmationError, OrderCancellationError };
 
 // ---------------------------------------------------------------------------
 // Client
@@ -91,7 +92,9 @@ export class IBClient {
       && /^\/iserver\/account\/[^/]+\/orders$/.test(urlPath);
     const isOrderCancellation = method.toUpperCase() === "DELETE"
       && /^\/iserver\/account\/[^/]+\/order\/[^/]+$/.test(urlPath);
-    const isOrderMutation = isOrderSubmission || isOrderCancellation;
+    const isOrderConfirmation = method.toUpperCase() === "POST"
+      && /^\/iserver\/reply\/[^/]+$/.test(urlPath);
+    const isOrderMutation = isOrderSubmission || isOrderCancellation || isOrderConfirmation;
     Logger.log(`[REQUEST-${requestId}] ${method} ${urlPath}`, {
       timeout: options?.timeout ?? 30000,
       headers: options?.headers,

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -19,9 +19,11 @@ import {
   prepareOrder,
   submitPreparedOrder,
   confirmOrder,
+  cancelOrder,
   getOrderStatus,
   getOrders,
   OrderSubmissionError,
+  OrderCancellationError,
   type PreparedOrder,
 } from "./ib-client/orders.js";
 import { getAlerts, createAlert, activateAlert, deleteAlert } from "./ib-client/alerts.js";
@@ -39,7 +41,7 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TICKLER_COOKIE_ENV = "IB_TICKLER_COOKIE_HEADER";
 
-export { SymbolNotFoundError, InvalidOrderContractError, OrderSubmissionError };
+export { SymbolNotFoundError, InvalidOrderContractError, OrderSubmissionError, OrderCancellationError };
 
 // ---------------------------------------------------------------------------
 // Client
@@ -87,10 +89,13 @@ export class IBClient {
     const requestId = Math.random().toString(36).substr(2, 9);
     const isOrderSubmission = method.toUpperCase() === "POST"
       && /^\/iserver\/account\/[^/]+\/orders$/.test(urlPath);
+    const isOrderCancellation = method.toUpperCase() === "DELETE"
+      && /^\/iserver\/account\/[^/]+\/order\/[^/]+$/.test(urlPath);
+    const isOrderMutation = isOrderSubmission || isOrderCancellation;
     Logger.log(`[REQUEST-${requestId}] ${method} ${urlPath}`, {
       timeout: options?.timeout ?? 30000,
       headers: options?.headers,
-      data: isOrderSubmission ? "[REDACTED ORDER REQUEST]" : options?.body,
+      data: isOrderMutation ? "[REDACTED ORDER REQUEST]" : options?.body,
     });
 
     if (!this.isAuthenticated) {
@@ -106,7 +111,7 @@ export class IBClient {
       Logger.log(`[RESPONSE-${requestId}] ${result.status} ${result.statusText}`, {
         url: urlPath,
         responseSize: JSON.stringify(result.data).length,
-        dataPreview: isOrderSubmission
+        dataPreview: isOrderMutation
           ? "[REDACTED ORDER RESPONSE]"
           : JSON.stringify(result.data).substring(0, 500) + "...",
       });
@@ -118,7 +123,7 @@ export class IBClient {
           status: error.response.status,
           statusText: error.response.statusText,
           message: error.message,
-          responseData: isOrderSubmission ? "[REDACTED ORDER RESPONSE]" : error.response.data,
+          responseData: isOrderMutation ? "[REDACTED ORDER RESPONSE]" : error.response.data,
         });
       } else {
         Logger.error(`[ERROR-${requestId}] Request failed:`, error instanceof Error ? error.message : String(error));
@@ -561,6 +566,10 @@ export class IBClient {
 
   async confirmOrder(replyId: string, messageIds: string[]): Promise<unknown> {
     return confirmOrder(this, replyId, messageIds);
+  }
+
+  async cancelOrder(accountId: string, orderId: string): Promise<unknown> {
+    return cancelOrder(this, accountId, orderId);
   }
 
   async getOrderStatus(orderId: string): Promise<unknown> {

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -76,10 +76,12 @@ export class IBClient {
     options?: RequestOptions,
   ): Promise<HttpResponse<T>> {
     const requestId = Math.random().toString(36).substr(2, 9);
+    const isOrderSubmission = method.toUpperCase() === "POST"
+      && /^\/iserver\/account\/[^/]+\/orders$/.test(urlPath);
     Logger.log(`[REQUEST-${requestId}] ${method} ${urlPath}`, {
       timeout: options?.timeout ?? 30000,
       headers: options?.headers,
-      data: options?.body,
+      data: isOrderSubmission ? "[REDACTED ORDER REQUEST]" : options?.body,
     });
 
     if (!this.isAuthenticated) {
@@ -95,7 +97,9 @@ export class IBClient {
       Logger.log(`[RESPONSE-${requestId}] ${result.status} ${result.statusText}`, {
         url: urlPath,
         responseSize: JSON.stringify(result.data).length,
-        dataPreview: JSON.stringify(result.data).substring(0, 500) + "...",
+        dataPreview: isOrderSubmission
+          ? "[REDACTED ORDER RESPONSE]"
+          : JSON.stringify(result.data).substring(0, 500) + "...",
       });
       return result;
     } catch (error: unknown) {
@@ -105,7 +109,7 @@ export class IBClient {
           status: error.response.status,
           statusText: error.response.statusText,
           message: error.message,
-          responseData: error.response.data,
+          responseData: isOrderSubmission ? "[REDACTED ORDER RESPONSE]" : error.response.data,
         });
       } else {
         Logger.error(`[ERROR-${requestId}] Request failed:`, error instanceof Error ? error.message : String(error));

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -14,7 +14,7 @@ import {
 import { getAccountInfo, getPositions } from "./ib-client/accounts.js";
 import { getMarketData } from "./ib-client/market-data.js";
 import { getOptionChain, resolveOptionConid } from "./ib-client/options.js";
-import { placeOrder, confirmOrder, getOrderStatus, getOrders } from "./ib-client/orders.js";
+import { placeOrder, confirmOrder, getOrderStatus, getOrders, OrderSubmissionError } from "./ib-client/orders.js";
 import { getAlerts, createAlert, activateAlert, deleteAlert } from "./ib-client/alerts.js";
 import {
   type AuthStatusResponse,
@@ -30,7 +30,7 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TICKLER_COOKIE_ENV = "IB_TICKLER_COOKIE_HEADER";
 
-export { SymbolNotFoundError, InvalidOrderContractError };
+export { SymbolNotFoundError, InvalidOrderContractError, OrderSubmissionError };
 
 // ---------------------------------------------------------------------------
 // Client

--- a/src/ib-client.ts
+++ b/src/ib-client.ts
@@ -95,7 +95,8 @@ export class IBClient {
     const isOrderConfirmation = method.toUpperCase() === "POST"
       && /^\/iserver\/reply\/[^/]+$/.test(urlPath);
     const isOrderMutation = isOrderSubmission || isOrderCancellation || isOrderConfirmation;
-    Logger.log(`[REQUEST-${requestId}] ${method} ${urlPath}`, {
+    const logUrlPath = isOrderConfirmation ? "/iserver/reply/[REDACTED]" : urlPath;
+    Logger.log(`[REQUEST-${requestId}] ${method} ${logUrlPath}`, {
       timeout: options?.timeout ?? 30000,
       headers: options?.headers,
       data: isOrderMutation ? "[REDACTED ORDER REQUEST]" : options?.body,
@@ -112,7 +113,7 @@ export class IBClient {
     try {
       const result = await this.client.request<T>(method, urlPath, options);
       Logger.log(`[RESPONSE-${requestId}] ${result.status} ${result.statusText}`, {
-        url: urlPath,
+        url: logUrlPath,
         responseSize: JSON.stringify(result.data).length,
         dataPreview: isOrderMutation
           ? "[REDACTED ORDER RESPONSE]"
@@ -122,7 +123,7 @@ export class IBClient {
     } catch (error: unknown) {
       if (error instanceof HttpError) {
         Logger.error(`[ERROR-${requestId}] Request failed:`, {
-          url: urlPath,
+          url: logUrlPath,
           status: error.response.status,
           statusText: error.response.statusText,
           message: error.message,

--- a/src/ib-client/orders.ts
+++ b/src/ib-client/orders.ts
@@ -1,6 +1,5 @@
 import { Logger } from "../logger.js";
 import type { IBClientRequester } from "./accounts.js";
-import { resolveContract } from "./options.js";
 import {
   type ContractSearch,
   type OrderPayload,
@@ -8,8 +7,31 @@ import {
   type OrderRequest,
   AuthenticationError,
   SymbolNotFoundError,
+  InvalidOrderContractError,
   isAuthenticationError,
 } from "./types.js";
+
+function isStockSearchResult(contract: ContractSearch): boolean {
+  return contract.secType === "STK" || contract.sections?.some((section) => section.secType === "STK") === true;
+}
+
+async function resolveAuthoritativeStock(
+  client: IBClientRequester,
+  conid: number,
+  expectedSymbol?: string,
+): Promise<ContractSearch> {
+  const response = await client.request<ContractSearch>("GET", `/iserver/contract/${conid}/info`);
+  const contract = response.data;
+  if (!contract || Number(contract.conid) !== conid || contract.secType !== "STK") {
+    throw new InvalidOrderContractError(`Contract ${conid} is not an authoritative STK stock contract`);
+  }
+  if (expectedSymbol && contract.symbol.toUpperCase() !== expectedSymbol.toUpperCase()) {
+    throw new InvalidOrderContractError(
+      `Contract ${conid} symbol ${contract.symbol} does not match requested stock ${expectedSymbol}`,
+    );
+  }
+  return contract;
+}
 
 function normalizeAccountId(account: unknown): string | undefined {
   if (!account) return undefined;
@@ -65,9 +87,9 @@ async function getOrderAccountIds(client: IBClientRequester): Promise<string[]> 
 export async function placeOrder(client: IBClientRequester, orderRequest: OrderRequest): Promise<unknown> {
   try {
     if (orderRequest.conid !== undefined) {
-      const contract = await resolveContract(client, orderRequest);
+      const contract = await resolveAuthoritativeStock(client, orderRequest.conid, orderRequest.symbol);
       const order: OrderPayload = {
-        conid: contract.conid,
+        conid: Number(contract.conid),
         cOID: orderRequest.clientOrderId,
         orderType: orderRequest.orderType,
         side: orderRequest.action,
@@ -98,7 +120,18 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
       throw new SymbolNotFoundError(`Symbol ${orderRequest.symbol}${orderRequest.exchange ? " on " + orderRequest.exchange : ""} not found`);
     }
 
-    const contract = searchResponse.data[0];
+    const stockCandidates = searchResponse.data.filter(isStockSearchResult);
+    if (stockCandidates.length !== 1) {
+      const reason = stockCandidates.length === 0 ? "no STK stock contract" : "ambiguous STK stock contracts";
+      throw new InvalidOrderContractError(`Symbol ${orderRequest.symbol} resolved to ${reason}`);
+    }
+
+    const searchContract = stockCandidates[0];
+    const contract = await resolveAuthoritativeStock(
+      client,
+      Number(searchContract.conid),
+      orderRequest.symbol,
+    );
     const order: OrderPayload = {
       conid: Number(contract.conid),
       cOID: orderRequest.clientOrderId,
@@ -121,6 +154,7 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
       throw new AuthenticationError("Authentication required to place orders. Please authenticate with Interactive Brokers first.");
     }
     if (error instanceof SymbolNotFoundError) throw error;
+    if (error instanceof InvalidOrderContractError) throw error;
     throw new Error("Failed to place order");
   }
 }

--- a/src/ib-client/orders.ts
+++ b/src/ib-client/orders.ts
@@ -40,6 +40,28 @@ export class OrderSubmissionError extends Error {
   }
 }
 
+export class OrderCancellationError extends Error {
+  readonly status: number;
+  readonly ibkrBody: unknown;
+
+  constructor(options: {
+    message: string;
+    status: number;
+    ibkrBody: unknown;
+    cause?: unknown;
+  }) {
+    super(options.message, { cause: options.cause });
+    this.name = "OrderCancellationError";
+    this.status = options.status;
+    Object.defineProperty(this, "ibkrBody", {
+      value: options.ibkrBody,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+  }
+}
+
 export interface PreparedOrder {
   accountId: string;
   order: OrderPayload;
@@ -83,6 +105,22 @@ function transportCode(error: unknown): string | undefined {
   const code = candidate.code ?? candidate.cause?.code;
   if (typeof code === "string") return code;
   return typeof candidate.name === "string" ? candidate.name : undefined;
+}
+
+function httpErrorSignalsAuthentication(error: HttpError): boolean {
+  if (error.response.status === 401 || error.response.status === 403) return true;
+  let body: string;
+  try {
+    body = typeof error.response.data === "string"
+      ? error.response.data
+      : JSON.stringify(error.response.data);
+  } catch {
+    return false;
+  }
+  const normalized = body.toLowerCase();
+  return normalized.includes("not authenticated")
+    || normalized.includes("authentication required")
+    || normalized.includes("unauthorized");
 }
 
 async function submitOrder(
@@ -272,6 +310,43 @@ export async function confirmOrder(client: IBClientRequester, replyId: string, m
       throw new AuthenticationError("Authentication required to confirm orders. Please authenticate with Interactive Brokers first.");
     }
     throw new Error("Failed to confirm order: " + (error instanceof Error ? error.message : String(error)));
+  }
+}
+
+export async function cancelOrder(
+  client: IBClientRequester,
+  accountId: string,
+  orderId: string,
+): Promise<unknown> {
+  try {
+    const response = await client.request(
+      "DELETE",
+      `/iserver/account/${encodeURIComponent(accountId)}/order/${encodeURIComponent(orderId)}`,
+    );
+    return response.data;
+  } catch (error: unknown) {
+    // Preserve explicit authentication failures so the handler can return the
+    // normal browser-auth guidance. Do not classify every HTTP 500 as auth here:
+    // cancellation rejections must retain their broker status and body.
+    if (error instanceof HttpError && httpErrorSignalsAuthentication(error)) {
+      Logger.error("Failed to cancel order: authentication required");
+      throw error;
+    }
+    if (error instanceof HttpError) {
+      Logger.error("Failed to cancel order:", {
+        name: "OrderCancellationError",
+        status: error.response.status,
+      });
+      throw new OrderCancellationError({
+        message: `Order cancellation failed with HTTP status ${error.response.status}`,
+        status: error.response.status,
+        ibkrBody: error.response.data,
+        cause: error,
+      });
+    }
+    if (isAuthenticationError(error)) throw error;
+    Logger.error("Failed to cancel order:", error instanceof Error ? error.message : String(error));
+    throw error;
   }
 }
 

--- a/src/ib-client/orders.ts
+++ b/src/ib-client/orders.ts
@@ -62,6 +62,34 @@ export class OrderCancellationError extends Error {
   }
 }
 
+export class OrderConfirmationError extends Error {
+  readonly status?: number;
+  readonly ibkrBody?: unknown;
+  readonly transportCode?: string;
+  readonly submissionUncertain: true;
+
+  constructor(options: {
+    message: string;
+    status?: number;
+    ibkrBody?: unknown;
+    transportCode?: string;
+    submissionUncertain: true;
+    cause?: unknown;
+  }) {
+    super(options.message, { cause: options.cause });
+    this.name = "OrderConfirmationError";
+    this.status = options.status;
+    Object.defineProperty(this, "ibkrBody", {
+      value: options.ibkrBody,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    this.transportCode = options.transportCode;
+    this.submissionUncertain = true;
+  }
+}
+
 export interface PreparedOrder {
   accountId: string;
   order: OrderPayload;
@@ -298,18 +326,26 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
 
 export async function confirmOrder(client: IBClientRequester, replyId: string, messageIds: string[]): Promise<unknown> {
   try {
-    Logger.log(`Confirming order with reply ID ${replyId} and message IDs:`, messageIds);
     const response = await client.request("POST", `/iserver/reply/${replyId}`, {
       body: { confirmed: true, messageIds },
     });
-    Logger.log("Order confirmation response:", response.data);
     return response.data;
   } catch (error: unknown) {
-    Logger.error("Failed to confirm order:", error);
-    if (isAuthenticationError(error)) {
-      throw new AuthenticationError("Authentication required to confirm orders. Please authenticate with Interactive Brokers first.");
+    if (error instanceof HttpError) {
+      throw new OrderConfirmationError({
+        message: `Order confirmation outcome is uncertain after HTTP status ${error.response.status}`,
+        status: error.response.status,
+        ibkrBody: error.response.data,
+        submissionUncertain: true,
+        cause: error,
+      });
     }
-    throw new Error("Failed to confirm order: " + (error instanceof Error ? error.message : String(error)));
+    throw new OrderConfirmationError({
+      message: "Order confirmation outcome is uncertain because the transport failed before a response was received",
+      transportCode: transportCode(error),
+      submissionUncertain: true,
+      cause: error,
+    });
   }
 }
 

--- a/src/ib-client/orders.ts
+++ b/src/ib-client/orders.ts
@@ -64,38 +64,24 @@ async function getOrderAccountIds(client: IBClientRequester): Promise<string[]> 
 
 export async function placeOrder(client: IBClientRequester, orderRequest: OrderRequest): Promise<unknown> {
   try {
-    if (orderRequest.conid !== undefined || orderRequest.secType === "OPT") {
+    if (orderRequest.conid !== undefined) {
       const contract = await resolveContract(client, orderRequest);
       const order: OrderPayload = {
         conid: contract.conid,
+        cOID: orderRequest.clientOrderId,
         orderType: orderRequest.orderType,
         side: orderRequest.action,
         quantity: Number(orderRequest.quantity),
+        price: Number(orderRequest.price),
         tif: orderRequest.tif || "DAY",
       };
 
       if (orderRequest.exchange) order.exchange = orderRequest.exchange;
-      if (contract.secType === "OPT" || orderRequest.secType === "OPT") order.secType = "OPT";
-      if (orderRequest.orderType === "LMT" && orderRequest.price !== undefined) {
-        order.price = Number(orderRequest.price);
-      }
-      if (orderRequest.orderType === "STP" && orderRequest.stopPrice !== undefined) {
-        order.auxPrice = Number(orderRequest.stopPrice);
-      }
-
       const response = await client.request<OrderConfirmation[]>(
         "POST",
         `/iserver/account/${orderRequest.accountId}/orders`,
         { body: { orders: [order] } },
       );
-
-      if (Array.isArray(response.data) && response.data.length > 0) {
-        const first = response.data[0];
-        if (first.id && first.message && first.messageIds && orderRequest.suppressConfirmations) {
-          Logger.log("Order confirmation received, auto-confirming", first);
-          return await confirmOrder(client, first.id, first.messageIds);
-        }
-      }
 
       return response.data;
     }
@@ -115,27 +101,19 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
     const contract = searchResponse.data[0];
     const order: OrderPayload = {
       conid: Number(contract.conid),
+      cOID: orderRequest.clientOrderId,
       orderType: orderRequest.orderType,
       side: orderRequest.action,
       quantity: Number(orderRequest.quantity),
+      price: Number(orderRequest.price),
       tif: orderRequest.tif || "DAY",
     };
     if (orderRequest.exchange) order.exchange = orderRequest.exchange;
-    if (orderRequest.orderType === "LMT" && orderRequest.price !== undefined) order.price = Number(orderRequest.price);
-    if (orderRequest.orderType === "STP" && orderRequest.stopPrice !== undefined) order.auxPrice = Number(orderRequest.stopPrice);
-
     const response = await client.request<OrderConfirmation[]>("POST",
       `/iserver/account/${orderRequest.accountId}/orders`,
       { body: { orders: [order] } },
     );
 
-    if (Array.isArray(response.data) && response.data.length > 0) {
-      const first = response.data[0];
-      if (first.id && first.message && first.messageIds && orderRequest.suppressConfirmations) {
-        Logger.log("Order confirmation received, automatically confirming...", first);
-        return await confirmOrder(client, first.id, first.messageIds);
-      }
-    }
     return response.data;
   } catch (error: unknown) {
     Logger.error("Failed to place order:", error);

--- a/src/ib-client/orders.ts
+++ b/src/ib-client/orders.ts
@@ -40,22 +40,6 @@ export class OrderSubmissionError extends Error {
   }
 }
 
-function isExplicitBrokerRejection(status: number, body: unknown): boolean {
-  if (status < 400 || status >= 500 || status === 408 || status === 425 || status === 429) {
-    return false;
-  }
-  const candidates = Array.isArray(body) ? body : [body];
-  return candidates.some((candidate) => {
-    if (!candidate || typeof candidate !== "object") return false;
-    const value = candidate as Record<string, unknown>;
-    const code = value.errorCode ?? value.error_code;
-    const message = value.error ?? value.message;
-    return (typeof code === "number" || (typeof code === "string" && /^\d+$/.test(code)))
-      && typeof message === "string"
-      && /reject|insufficient|not allowed|exceed/i.test(message);
-  });
-}
-
 export interface PreparedOrder {
   accountId: string;
   order: OrderPayload;
@@ -115,14 +99,11 @@ async function submitOrder(
     return response.data;
   } catch (error) {
     if (error instanceof HttpError) {
-      const definiteRejection = isExplicitBrokerRejection(error.response.status, error.response.data);
       throw new OrderSubmissionError({
-        message: definiteRejection
-          ? `IBKR explicitly rejected order submission with HTTP status ${error.response.status}`
-          : `Order submission outcome is uncertain after HTTP status ${error.response.status}`,
+        message: `Order submission outcome is uncertain after HTTP status ${error.response.status}`,
         status: error.response.status,
         ibkrBody: error.response.data,
-        submissionUncertain: !definiteRejection,
+        submissionUncertain: true,
         cause: error,
       });
     }

--- a/src/ib-client/orders.ts
+++ b/src/ib-client/orders.ts
@@ -1,4 +1,5 @@
 import { Logger } from "../logger.js";
+import { HttpError } from "../http.js";
 import type { IBClientRequester } from "./accounts.js";
 import {
   type ContractSearch,
@@ -10,6 +11,29 @@ import {
   InvalidOrderContractError,
   isAuthenticationError,
 } from "./types.js";
+
+export class OrderSubmissionError extends Error {
+  readonly status?: number;
+  readonly ibkrBody?: unknown;
+  readonly transportCode?: string;
+  readonly submissionUncertain: boolean;
+
+  constructor(options: {
+    message: string;
+    status?: number;
+    ibkrBody?: unknown;
+    transportCode?: string;
+    submissionUncertain: boolean;
+    cause?: unknown;
+  }) {
+    super(options.message, { cause: options.cause });
+    this.name = "OrderSubmissionError";
+    this.status = options.status;
+    this.ibkrBody = options.ibkrBody;
+    this.transportCode = options.transportCode;
+    this.submissionUncertain = options.submissionUncertain;
+  }
+}
 
 async function fetchAuthoritativeContract(
   client: IBClientRequester,
@@ -32,12 +56,54 @@ async function resolveAuthoritativeStock(
   if (contract.secType !== "STK") {
     throw new InvalidOrderContractError(`Contract ${conid} is not an authoritative STK stock contract`);
   }
+  if (contract.currency !== "USD") {
+    throw new InvalidOrderContractError(`Contract ${conid} is not an authoritative USD stock contract`);
+  }
   if (expectedSymbol && contract.symbol.toUpperCase() !== expectedSymbol.toUpperCase()) {
     throw new InvalidOrderContractError(
       `Contract ${conid} symbol ${contract.symbol} does not match requested stock ${expectedSymbol}`,
     );
   }
   return contract;
+}
+
+function transportCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const candidate = error as { code?: unknown; cause?: { code?: unknown }; name?: unknown };
+  const code = candidate.code ?? candidate.cause?.code;
+  if (typeof code === "string") return code;
+  return typeof candidate.name === "string" ? candidate.name : undefined;
+}
+
+async function submitOrder(
+  client: IBClientRequester,
+  accountId: string,
+  order: OrderPayload,
+): Promise<unknown> {
+  try {
+    const response = await client.request<OrderConfirmation[]>(
+      "POST",
+      `/iserver/account/${accountId}/orders`,
+      { body: { orders: [order] } },
+    );
+    return response.data;
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw new OrderSubmissionError({
+        message: `IBKR rejected order submission with HTTP status ${error.response.status}`,
+        status: error.response.status,
+        ibkrBody: error.response.data,
+        submissionUncertain: false,
+        cause: error,
+      });
+    }
+    throw new OrderSubmissionError({
+      message: "Order submission outcome is uncertain because the transport failed before a response was received",
+      transportCode: transportCode(error),
+      submissionUncertain: true,
+      cause: error,
+    });
+  }
 }
 
 function normalizeAccountId(account: unknown): string | undefined {
@@ -106,13 +172,7 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
       };
 
       if (orderRequest.exchange) order.exchange = orderRequest.exchange;
-      const response = await client.request<OrderConfirmation[]>(
-        "POST",
-        `/iserver/account/${orderRequest.accountId}/orders`,
-        { body: { orders: [order] } },
-      );
-
-      return response.data;
+      return submitOrder(client, orderRequest.accountId, order);
     }
 
     if (!orderRequest.symbol) {
@@ -133,10 +193,11 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
     );
     const stockCandidates = authoritativeCandidates.filter(
       (candidate) => candidate.secType === "STK"
+        && candidate.currency === "USD"
         && candidate.symbol.toUpperCase() === orderRequest.symbol!.toUpperCase(),
     );
     if (stockCandidates.length !== 1) {
-      const reason = stockCandidates.length === 0 ? "no STK stock contract" : "ambiguous STK stock contracts";
+      const reason = stockCandidates.length === 0 ? "no eligible USD STK stock contract" : "ambiguous eligible USD STK stock contracts";
       throw new InvalidOrderContractError(`Symbol ${orderRequest.symbol} resolved to ${reason}`);
     }
 
@@ -151,12 +212,7 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
       tif: orderRequest.tif || "DAY",
     };
     if (orderRequest.exchange) order.exchange = orderRequest.exchange;
-    const response = await client.request<OrderConfirmation[]>("POST",
-      `/iserver/account/${orderRequest.accountId}/orders`,
-      { body: { orders: [order] } },
-    );
-
-    return response.data;
+    return submitOrder(client, orderRequest.accountId, order);
   } catch (error: unknown) {
     Logger.error("Failed to place order:", error);
     if (isAuthenticationError(error)) {
@@ -164,6 +220,7 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
     }
     if (error instanceof SymbolNotFoundError) throw error;
     if (error instanceof InvalidOrderContractError) throw error;
+    if (error instanceof OrderSubmissionError) throw error;
     throw new Error("Failed to place order");
   }
 }

--- a/src/ib-client/orders.ts
+++ b/src/ib-client/orders.ts
@@ -29,10 +29,31 @@ export class OrderSubmissionError extends Error {
     super(options.message, { cause: options.cause });
     this.name = "OrderSubmissionError";
     this.status = options.status;
-    this.ibkrBody = options.ibkrBody;
+    Object.defineProperty(this, "ibkrBody", {
+      value: options.ibkrBody,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
     this.transportCode = options.transportCode;
     this.submissionUncertain = options.submissionUncertain;
   }
+}
+
+function isExplicitBrokerRejection(status: number, body: unknown): boolean {
+  if (status < 400 || status >= 500 || status === 408 || status === 425 || status === 429) {
+    return false;
+  }
+  const candidates = Array.isArray(body) ? body : [body];
+  return candidates.some((candidate) => {
+    if (!candidate || typeof candidate !== "object") return false;
+    const value = candidate as Record<string, unknown>;
+    const code = value.errorCode ?? value.error_code ?? value.code;
+    const message = value.error ?? value.message;
+    return (typeof code === "number" || typeof code === "string")
+      && typeof message === "string"
+      && /reject|invalid|insufficient|not allowed|cannot|exceed/i.test(message);
+  });
 }
 
 async function fetchAuthoritativeContract(
@@ -89,11 +110,14 @@ async function submitOrder(
     return response.data;
   } catch (error) {
     if (error instanceof HttpError) {
+      const definiteRejection = isExplicitBrokerRejection(error.response.status, error.response.data);
       throw new OrderSubmissionError({
-        message: `IBKR rejected order submission with HTTP status ${error.response.status}`,
+        message: definiteRejection
+          ? `IBKR explicitly rejected order submission with HTTP status ${error.response.status}`
+          : `Order submission outcome is uncertain after HTTP status ${error.response.status}`,
         status: error.response.status,
         ibkrBody: error.response.data,
-        submissionUncertain: false,
+        submissionUncertain: !definiteRejection,
         cause: error,
       });
     }
@@ -214,7 +238,16 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
     if (orderRequest.exchange) order.exchange = orderRequest.exchange;
     return submitOrder(client, orderRequest.accountId, order);
   } catch (error: unknown) {
-    Logger.error("Failed to place order:", error);
+    if (error instanceof OrderSubmissionError) {
+      Logger.error("Failed to place order:", {
+        name: error.name,
+        status: error.status,
+        transportCode: error.transportCode,
+        submissionUncertain: error.submissionUncertain,
+      });
+    } else {
+      Logger.error("Failed to place order:", error);
+    }
     if (isAuthenticationError(error)) {
       throw new AuthenticationError("Authentication required to place orders. Please authenticate with Interactive Brokers first.");
     }

--- a/src/ib-client/orders.ts
+++ b/src/ib-client/orders.ts
@@ -11,8 +11,16 @@ import {
   isAuthenticationError,
 } from "./types.js";
 
-function isStockSearchResult(contract: ContractSearch): boolean {
-  return contract.secType === "STK" || contract.sections?.some((section) => section.secType === "STK") === true;
+async function fetchAuthoritativeContract(
+  client: IBClientRequester,
+  conid: number,
+): Promise<ContractSearch> {
+  const response = await client.request<ContractSearch>("GET", `/iserver/contract/${conid}/info`);
+  const contract = response.data;
+  if (!contract || Number(contract.conid) !== conid) {
+    throw new InvalidOrderContractError(`Contract ${conid} returned mismatched authoritative metadata`);
+  }
+  return contract;
 }
 
 async function resolveAuthoritativeStock(
@@ -20,9 +28,8 @@ async function resolveAuthoritativeStock(
   conid: number,
   expectedSymbol?: string,
 ): Promise<ContractSearch> {
-  const response = await client.request<ContractSearch>("GET", `/iserver/contract/${conid}/info`);
-  const contract = response.data;
-  if (!contract || Number(contract.conid) !== conid || contract.secType !== "STK") {
+  const contract = await fetchAuthoritativeContract(client, conid);
+  if (contract.secType !== "STK") {
     throw new InvalidOrderContractError(`Contract ${conid} is not an authoritative STK stock contract`);
   }
   if (expectedSymbol && contract.symbol.toUpperCase() !== expectedSymbol.toUpperCase()) {
@@ -120,18 +127,20 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
       throw new SymbolNotFoundError(`Symbol ${orderRequest.symbol}${orderRequest.exchange ? " on " + orderRequest.exchange : ""} not found`);
     }
 
-    const stockCandidates = searchResponse.data.filter(isStockSearchResult);
+    const candidateConids = [...new Set(searchResponse.data.map((candidate) => Number(candidate.conid)))];
+    const authoritativeCandidates = await Promise.all(
+      candidateConids.map((conid) => fetchAuthoritativeContract(client, conid)),
+    );
+    const stockCandidates = authoritativeCandidates.filter(
+      (candidate) => candidate.secType === "STK"
+        && candidate.symbol.toUpperCase() === orderRequest.symbol!.toUpperCase(),
+    );
     if (stockCandidates.length !== 1) {
       const reason = stockCandidates.length === 0 ? "no STK stock contract" : "ambiguous STK stock contracts";
       throw new InvalidOrderContractError(`Symbol ${orderRequest.symbol} resolved to ${reason}`);
     }
 
-    const searchContract = stockCandidates[0];
-    const contract = await resolveAuthoritativeStock(
-      client,
-      Number(searchContract.conid),
-      orderRequest.symbol,
-    );
+    const contract = stockCandidates[0];
     const order: OrderPayload = {
       conid: Number(contract.conid),
       cOID: orderRequest.clientOrderId,

--- a/src/ib-client/orders.ts
+++ b/src/ib-client/orders.ts
@@ -48,12 +48,17 @@ function isExplicitBrokerRejection(status: number, body: unknown): boolean {
   return candidates.some((candidate) => {
     if (!candidate || typeof candidate !== "object") return false;
     const value = candidate as Record<string, unknown>;
-    const code = value.errorCode ?? value.error_code ?? value.code;
+    const code = value.errorCode ?? value.error_code;
     const message = value.error ?? value.message;
-    return (typeof code === "number" || typeof code === "string")
+    return (typeof code === "number" || (typeof code === "string" && /^\d+$/.test(code)))
       && typeof message === "string"
-      && /reject|invalid|insufficient|not allowed|cannot|exceed/i.test(message);
+      && /reject|insufficient|not allowed|exceed/i.test(message);
   });
+}
+
+export interface PreparedOrder {
+  accountId: string;
+  order: OrderPayload;
 }
 
 async function fetchAuthoritativeContract(
@@ -181,11 +186,13 @@ async function getOrderAccountIds(client: IBClientRequester): Promise<string[]> 
   return [];
 }
 
-export async function placeOrder(client: IBClientRequester, orderRequest: OrderRequest): Promise<unknown> {
-  try {
-    if (orderRequest.conid !== undefined) {
-      const contract = await resolveAuthoritativeStock(client, orderRequest.conid, orderRequest.symbol);
-      const order: OrderPayload = {
+export async function prepareOrder(
+  client: IBClientRequester,
+  orderRequest: OrderRequest,
+): Promise<PreparedOrder> {
+  if (orderRequest.conid !== undefined) {
+    const contract = await resolveAuthoritativeStock(client, orderRequest.conid, orderRequest.symbol);
+    const order: OrderPayload = {
         conid: Number(contract.conid),
         cOID: orderRequest.clientOrderId,
         orderType: orderRequest.orderType,
@@ -193,40 +200,39 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
         quantity: Number(orderRequest.quantity),
         price: Number(orderRequest.price),
         tif: orderRequest.tif || "DAY",
-      };
+    };
+    if (orderRequest.exchange) order.exchange = orderRequest.exchange;
+    return { accountId: orderRequest.accountId, order };
+  }
 
-      if (orderRequest.exchange) order.exchange = orderRequest.exchange;
-      return submitOrder(client, orderRequest.accountId, order);
-    }
+  if (!orderRequest.symbol) {
+    throw new Error("Symbol is required when conid is not provided");
+  }
 
-    if (!orderRequest.symbol) {
-      throw new Error("Symbol is required when conid is not provided");
-    }
+  let searchUrl = `/iserver/secdef/search?symbol=${encodeURIComponent(orderRequest.symbol)}`;
+  if (orderRequest.exchange) searchUrl += `&name=${encodeURIComponent(orderRequest.exchange)}`;
+  const searchResponse = await client.request<ContractSearch[]>("GET", searchUrl);
 
-    let searchUrl = `/iserver/secdef/search?symbol=${encodeURIComponent(orderRequest.symbol)}`;
-    if (orderRequest.exchange) searchUrl += `&name=${encodeURIComponent(orderRequest.exchange)}`;
-    const searchResponse = await client.request<ContractSearch[]>("GET", searchUrl);
+  if (!searchResponse.data || searchResponse.data.length === 0) {
+    throw new SymbolNotFoundError(`Symbol ${orderRequest.symbol}${orderRequest.exchange ? " on " + orderRequest.exchange : ""} not found`);
+  }
 
-    if (!searchResponse.data || searchResponse.data.length === 0) {
-      throw new SymbolNotFoundError(`Symbol ${orderRequest.symbol}${orderRequest.exchange ? " on " + orderRequest.exchange : ""} not found`);
-    }
+  const candidateConids = [...new Set(searchResponse.data.map((candidate) => Number(candidate.conid)))];
+  const authoritativeCandidates = await Promise.all(
+    candidateConids.map((conid) => fetchAuthoritativeContract(client, conid)),
+  );
+  const stockCandidates = authoritativeCandidates.filter(
+    (candidate) => candidate.secType === "STK"
+      && candidate.currency === "USD"
+      && candidate.symbol.toUpperCase() === orderRequest.symbol!.toUpperCase(),
+  );
+  if (stockCandidates.length !== 1) {
+    const reason = stockCandidates.length === 0 ? "no eligible USD STK stock contract" : "ambiguous eligible USD STK stock contracts";
+    throw new InvalidOrderContractError(`Symbol ${orderRequest.symbol} resolved to ${reason}`);
+  }
 
-    const candidateConids = [...new Set(searchResponse.data.map((candidate) => Number(candidate.conid)))];
-    const authoritativeCandidates = await Promise.all(
-      candidateConids.map((conid) => fetchAuthoritativeContract(client, conid)),
-    );
-    const stockCandidates = authoritativeCandidates.filter(
-      (candidate) => candidate.secType === "STK"
-        && candidate.currency === "USD"
-        && candidate.symbol.toUpperCase() === orderRequest.symbol!.toUpperCase(),
-    );
-    if (stockCandidates.length !== 1) {
-      const reason = stockCandidates.length === 0 ? "no eligible USD STK stock contract" : "ambiguous eligible USD STK stock contracts";
-      throw new InvalidOrderContractError(`Symbol ${orderRequest.symbol} resolved to ${reason}`);
-    }
-
-    const contract = stockCandidates[0];
-    const order: OrderPayload = {
+  const contract = stockCandidates[0];
+  const order: OrderPayload = {
       conid: Number(contract.conid),
       cOID: orderRequest.clientOrderId,
       orderType: orderRequest.orderType,
@@ -234,9 +240,22 @@ export async function placeOrder(client: IBClientRequester, orderRequest: OrderR
       quantity: Number(orderRequest.quantity),
       price: Number(orderRequest.price),
       tif: orderRequest.tif || "DAY",
-    };
-    if (orderRequest.exchange) order.exchange = orderRequest.exchange;
-    return submitOrder(client, orderRequest.accountId, order);
+  };
+  if (orderRequest.exchange) order.exchange = orderRequest.exchange;
+  return { accountId: orderRequest.accountId, order };
+}
+
+export async function submitPreparedOrder(
+  client: IBClientRequester,
+  prepared: PreparedOrder,
+): Promise<unknown> {
+  return submitOrder(client, prepared.accountId, prepared.order);
+}
+
+export async function placeOrder(client: IBClientRequester, orderRequest: OrderRequest): Promise<unknown> {
+  try {
+    const prepared = await prepareOrder(client, orderRequest);
+    return await submitPreparedOrder(client, prepared);
   } catch (error: unknown) {
     if (error instanceof OrderSubmissionError) {
       Logger.error("Failed to place order:", {

--- a/src/ib-client/types.ts
+++ b/src/ib-client/types.ts
@@ -25,6 +25,7 @@ export interface ContractSearch {
   secType?: string;
   description?: string;
   companyHeader?: string;
+  currency?: string;
   sections?: ContractSection[];
 }
 

--- a/src/ib-client/types.ts
+++ b/src/ib-client/types.ts
@@ -22,6 +22,7 @@ export interface ContractSection {
 export interface ContractSearch {
   conid: number | string;
   symbol: string;
+  secType?: string;
   description?: string;
   companyHeader?: string;
   sections?: ContractSection[];
@@ -115,6 +116,13 @@ export class SymbolNotFoundError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "SymbolNotFoundError";
+  }
+}
+
+export class InvalidOrderContractError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidOrderContractError";
   }
 }
 

--- a/src/ib-client/types.ts
+++ b/src/ib-client/types.ts
@@ -54,14 +54,13 @@ export interface OrderConfirmation {
 
 export interface OrderPayload {
   conid: number;
+  cOID: string;
   orderType: string;
   side: string;
   quantity: number;
   tif: string;
-  secType?: string;
   exchange?: string;
-  price?: number;
-  auxPrice?: number;
+  price: number;
 }
 
 export interface AccountEntry {
@@ -83,14 +82,16 @@ export interface ContractLookupRequest {
   exchange?: string;
 }
 
-export interface OrderRequest extends ContractLookupRequest {
+export interface OrderRequest {
+  clientOrderId: string;
   accountId: string;
+  symbol?: string;
+  conid?: number;
   action: "BUY" | "SELL";
-  orderType: "MKT" | "LMT" | "STP";
+  orderType: "LMT";
   quantity: number;
-  price?: number;
-  stopPrice?: number;
-  suppressConfirmations?: boolean;
+  price: number;
+  exchange?: string;
   tif?: "DAY" | "GTC" | "IOC" | "OPG";
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,152 +6,16 @@ import { IBGatewayManager } from "./gateway-manager.js";
 import { config, parseReadOnlyMode } from "./config.js";
 import { registerTools } from "./tools.js";
 import { Logger } from "./logger.js";
+import { parseCliArgs, redactConfigForLogging } from "./cli-args.js";
 
-
-// Parse command line arguments
-function parseArgs(): z.infer<typeof configSchema> {
-  const args: any = {};
-  const argv = process.argv.slice(2);
-
-  // Log raw arguments for debugging
-  Logger.info(`🔍 Raw command line arguments: ${JSON.stringify(argv)}`);
-
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-
-    if (arg.startsWith('--')) {
-      const key = arg.slice(2);
-      const nextArg = argv[i + 1];
-
-      Logger.debug(`🔍 Processing flag: ${key}, nextArg: ${nextArg}`);
-
-      switch (key) {
-        case 'ib-username':
-          args.IB_USERNAME = nextArg;
-          Logger.debug(`🔍 Set IB_USERNAME to: ${nextArg}`);
-          i++;
-          break;
-        case 'ib-password':
-        case 'ib-password-auth':
-          args.IB_PASSWORD_AUTH = nextArg;
-          Logger.debug(`🔍 Set IB_PASSWORD_AUTH to: [REDACTED]`);
-          i++;
-          break;
-        case 'ib-auth-timeout':
-          args.IB_AUTH_TIMEOUT = parseInt(nextArg);
-          Logger.debug(`🔍 Set IB_AUTH_TIMEOUT to: ${nextArg}`);
-          i++;
-          break;
-        case 'ib-auth-wait-seconds':
-          args.IB_AUTH_WAIT_SECONDS = parseInt(nextArg);
-          Logger.debug(`🔍 Set IB_AUTH_WAIT_SECONDS to: ${nextArg}`);
-          i++;
-          break;
-        case 'ib-auth-poll-seconds':
-          args.IB_AUTH_POLL_SECONDS = parseInt(nextArg);
-          Logger.debug(`🔍 Set IB_AUTH_POLL_SECONDS to: ${nextArg}`);
-          i++;
-          break;
-
-        case 'ib-headless-mode':
-          // Support both --ib-headless-mode (boolean flag) and --ib-headless-mode=true/false
-          if (nextArg && !nextArg.startsWith('--')) {
-            args.IB_HEADLESS_MODE = nextArg.toLowerCase() === 'true';
-            Logger.debug(`🔍 Set IB_HEADLESS_MODE to: ${nextArg.toLowerCase() === 'true'} (from arg: ${nextArg})`);
-            i++;
-          } else {
-            args.IB_HEADLESS_MODE = true;
-            Logger.debug(`🔍 Set IB_HEADLESS_MODE to: true (flag only)`);
-          }
-          break;
-        case 'ib-paper-trading':
-          // Support both --ib-paper-trading (boolean flag) and --ib-paper-trading=true/false
-          if (nextArg && !nextArg.startsWith('--')) {
-            args.IB_PAPER_TRADING = nextArg.toLowerCase() === 'true';
-            Logger.debug(`🔍 Set IB_PAPER_TRADING to: ${nextArg.toLowerCase() === 'true'} (from arg: ${nextArg})`);
-            i++;
-          } else {
-            args.IB_PAPER_TRADING = true;
-            Logger.debug(`🔍 Set IB_PAPER_TRADING to: true (flag only)`);
-          }
-          break;
-        case 'ib-read-only-mode':
-          // Support both --ib-read-only-mode (boolean flag) and --ib-read-only-mode=true/false
-          if (nextArg && !nextArg.startsWith('--')) {
-            args.IB_READ_ONLY_MODE = parseReadOnlyMode(nextArg);
-            Logger.debug(`🔍 Set IB_READ_ONLY_MODE to: ${args.IB_READ_ONLY_MODE} (from arg: ${nextArg})`);
-            i++;
-          } else {
-            args.IB_READ_ONLY_MODE = true;
-            Logger.debug(`🔍 Set IB_READ_ONLY_MODE to: true (flag only)`);
-          }
-          break;
-        case 'ib-allowed-account-id':
-          args.IB_ALLOWED_ACCOUNT_ID = nextArg;
-          Logger.debug(`🔍 Set IB_ALLOWED_ACCOUNT_ID to: ${nextArg}`);
-          i++;
-          break;
-
-      }
-    } else if (arg.includes('=')) {
-      const [key, value] = arg.split('=', 2);
-      const cleanKey = key.startsWith('--') ? key.slice(2) : key;
-
-      Logger.debug(`🔍 Processing key=value: ${cleanKey}=${value}`);
-
-      switch (cleanKey) {
-        case 'ib-username':
-          args.IB_USERNAME = value;
-          Logger.debug(`🔍 Set IB_USERNAME to: ${value}`);
-          break;
-        case 'ib-password':
-        case 'ib-password-auth':
-          args.IB_PASSWORD_AUTH = value;
-          Logger.debug(`🔍 Set IB_PASSWORD_AUTH to: [REDACTED]`);
-          break;
-        case 'ib-auth-timeout':
-          args.IB_AUTH_TIMEOUT = parseInt(value);
-          Logger.debug(`🔍 Set IB_AUTH_TIMEOUT to: ${value}`);
-          break;
-        case 'ib-auth-wait-seconds':
-          args.IB_AUTH_WAIT_SECONDS = parseInt(value);
-          Logger.debug(`🔍 Set IB_AUTH_WAIT_SECONDS to: ${value}`);
-          break;
-        case 'ib-auth-poll-seconds':
-          args.IB_AUTH_POLL_SECONDS = parseInt(value);
-          Logger.debug(`🔍 Set IB_AUTH_POLL_SECONDS to: ${value}`);
-          break;
-
-        case 'ib-headless-mode':
-          args.IB_HEADLESS_MODE = value.toLowerCase() === 'true';
-          Logger.debug(`🔍 Set IB_HEADLESS_MODE to: ${value.toLowerCase() === 'true'} (from value: ${value})`);
-          break;
-        case 'ib-paper-trading':
-          args.IB_PAPER_TRADING = value.toLowerCase() === 'true';
-          Logger.debug(`🔍 Set IB_PAPER_TRADING to: ${value.toLowerCase() === 'true'} (from value: ${value})`);
-          break;
-        case 'ib-read-only-mode':
-          args.IB_READ_ONLY_MODE = parseReadOnlyMode(value);
-          Logger.debug(`🔍 Set IB_READ_ONLY_MODE to: ${args.IB_READ_ONLY_MODE} (from value: ${value})`);
-          break;
-        case 'ib-allowed-account-id':
-          args.IB_ALLOWED_ACCOUNT_ID = value;
-          Logger.debug(`🔍 Set IB_ALLOWED_ACCOUNT_ID to: ${value}`);
-          break;
-
-      }
-    }
-  }
-
-  Logger.info(`🔍 Parsed args: ${JSON.stringify(args, null, 2)}`);
-  return args;
-}
 
 // Optional: Define configuration schema for session configuration
 export const configSchema = z.object({
   // Authentication configuration
   IB_USERNAME: z.string().optional(),
   IB_PASSWORD_AUTH: z.string().optional(),
+  IB_TOTP_SECRET: z.string().optional(),
+  IB_FLEX_TOKEN: z.string().optional(),
   IB_AUTH_TIMEOUT: z.number().optional(),
   IB_AUTH_WAIT_SECONDS: z.number().optional(),
   IB_AUTH_POLL_SECONDS: z.number().optional(),
@@ -262,9 +126,7 @@ function IBMCP({ config: userConfig }: { config: z.infer<typeof configSchema> })
   };
 
   // Log the merged config for debugging (but redact sensitive info)
-  const logConfig = { ...mergedConfig };
-  if (logConfig.IB_PASSWORD_AUTH) logConfig.IB_PASSWORD_AUTH = '[REDACTED]';
-  if (logConfig.IB_PASSWORD) logConfig.IB_PASSWORD = '[REDACTED]';
+  const logConfig = redactConfigForLogging({ ...mergedConfig });
   Logger.info(`🔍 Final merged config: ${JSON.stringify(logConfig, null, 2)}`);
 
   // Create IB Client with default port initially - this will be updated once gateway starts
@@ -315,7 +177,7 @@ if (isMainModule) {
 
   // Parse command line arguments and merge with environment variables
   // Priority: args > env > defaults
-  const argsConfig = parseArgs();
+  const argsConfig = parseCliArgs() as z.infer<typeof configSchema>;
   const envConfig = {
     IB_USERNAME: process.env.IB_USERNAME,
     IB_PASSWORD_AUTH: process.env.IB_PASSWORD_AUTH || process.env.IB_PASSWORD,
@@ -329,8 +191,7 @@ if (isMainModule) {
   };
 
   // Log environment config for debugging
-  const logEnvConfig = { ...envConfig };
-  if (logEnvConfig.IB_PASSWORD_AUTH) logEnvConfig.IB_PASSWORD_AUTH = '[REDACTED]';
+  const logEnvConfig = redactConfigForLogging({ ...envConfig });
   Logger.info(`🔍 Environment config: ${JSON.stringify(logEnvConfig, null, 2)}`);
 
   // Merge configs with priority: args > env > defaults
@@ -340,8 +201,7 @@ if (isMainModule) {
   };
 
   // Log final config before cleanup
-  const logFinalConfig = { ...finalConfig };
-  if (logFinalConfig.IB_PASSWORD_AUTH) logFinalConfig.IB_PASSWORD_AUTH = '[REDACTED]';
+  const logFinalConfig = redactConfigForLogging({ ...finalConfig });
   Logger.info(`🔍 Final config before cleanup: ${JSON.stringify(logFinalConfig, null, 2)}`);
 
   // Remove undefined values
@@ -352,8 +212,7 @@ if (isMainModule) {
   });
 
   // Log final config after cleanup
-  const logFinalConfigAfter = { ...finalConfig };
-  if (logFinalConfigAfter.IB_PASSWORD_AUTH) logFinalConfigAfter.IB_PASSWORD_AUTH = '[REDACTED]';
+  const logFinalConfigAfter = redactConfigForLogging({ ...finalConfig });
   Logger.info(`🔍 Final config after cleanup: ${JSON.stringify(logFinalConfigAfter, null, 2)}`);
 
   const stdioTransport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { IBClient } from "./ib-client.js";
 import { IBGatewayManager } from "./gateway-manager.js";
-import { config } from "./config.js";
+import { config, parseReadOnlyMode } from "./config.js";
 import { registerTools } from "./tools.js";
 import { Logger } from "./logger.js";
 
@@ -74,16 +74,22 @@ function parseArgs(): z.infer<typeof configSchema> {
             args.IB_PAPER_TRADING = true;
             Logger.debug(`🔍 Set IB_PAPER_TRADING to: true (flag only)`);
           }
+          break;
         case 'ib-read-only-mode':
           // Support both --ib-read-only-mode (boolean flag) and --ib-read-only-mode=true/false
           if (nextArg && !nextArg.startsWith('--')) {
-            args.IB_READ_ONLY_MODE = nextArg.toLowerCase() === 'true';
-            Logger.debug(`🔍 Set IB_READ_ONLY_MODE to: ${nextArg.toLowerCase() === 'true'} (from arg: ${nextArg})`);
+            args.IB_READ_ONLY_MODE = parseReadOnlyMode(nextArg);
+            Logger.debug(`🔍 Set IB_READ_ONLY_MODE to: ${args.IB_READ_ONLY_MODE} (from arg: ${nextArg})`);
             i++;
           } else {
             args.IB_READ_ONLY_MODE = true;
             Logger.debug(`🔍 Set IB_READ_ONLY_MODE to: true (flag only)`);
           }
+          break;
+        case 'ib-allowed-account-id':
+          args.IB_ALLOWED_ACCOUNT_ID = nextArg;
+          Logger.debug(`🔍 Set IB_ALLOWED_ACCOUNT_ID to: ${nextArg}`);
+          i++;
           break;
 
       }
@@ -125,8 +131,12 @@ function parseArgs(): z.infer<typeof configSchema> {
           Logger.debug(`🔍 Set IB_PAPER_TRADING to: ${value.toLowerCase() === 'true'} (from value: ${value})`);
           break;
         case 'ib-read-only-mode':
-          args.IB_READ_ONLY_MODE = value.toLowerCase() === 'true';
-          Logger.debug(`🔍 Set IB_READ_ONLY_MODE to: ${value.toLowerCase() === 'true'} (from value: ${value})`);
+          args.IB_READ_ONLY_MODE = parseReadOnlyMode(value);
+          Logger.debug(`🔍 Set IB_READ_ONLY_MODE to: ${args.IB_READ_ONLY_MODE} (from value: ${value})`);
+          break;
+        case 'ib-allowed-account-id':
+          args.IB_ALLOWED_ACCOUNT_ID = value;
+          Logger.debug(`🔍 Set IB_ALLOWED_ACCOUNT_ID to: ${value}`);
           break;
 
       }
@@ -152,6 +162,7 @@ export const configSchema = z.object({
 
   // Read-only mode configuration
   IB_READ_ONLY_MODE: z.boolean().optional(),
+  IB_ALLOWED_ACCOUNT_ID: z.string().optional(),
 });
 
 // Global gateway manager instance
@@ -312,7 +323,8 @@ if (isMainModule) {
     IB_AUTH_WAIT_SECONDS: process.env.IB_AUTH_WAIT_SECONDS ? parseInt(process.env.IB_AUTH_WAIT_SECONDS) : undefined,
     IB_AUTH_POLL_SECONDS: process.env.IB_AUTH_POLL_SECONDS ? parseInt(process.env.IB_AUTH_POLL_SECONDS) : undefined,
     IB_HEADLESS_MODE: process.env.IB_HEADLESS_MODE === 'true',
-    IB_READ_ONLY_MODE: process.env.IB_READ_ONLY_MODE === 'true',
+    IB_READ_ONLY_MODE: parseReadOnlyMode(process.env.IB_READ_ONLY_MODE),
+    IB_ALLOWED_ACCOUNT_ID: process.env.IB_ALLOWED_ACCOUNT_ID,
 
   };
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, existsSync, mkdirSync } from 'fs';
+import { appendFileSync, chmodSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
@@ -12,13 +12,19 @@ export class Logger {
                                        process.argv.includes('--log-console');
 
   private static ensureLogDir() {
-    if (Logger.enableLogging && !existsSync(Logger.logDir)) {
+    if (!Logger.enableLogging) return;
+    if (!existsSync(Logger.logDir)) {
       try {
-        mkdirSync(Logger.logDir, { recursive: true });
+        mkdirSync(Logger.logDir, { recursive: true, mode: 0o700 });
       } catch (error) {
         // If we can't create log dir, disable logging
         Logger.enableLogging = false;
       }
+    }
+    try {
+      chmodSync(Logger.logDir, 0o700);
+    } catch {
+      Logger.enableLogging = false;
     }
   }
 
@@ -32,7 +38,8 @@ export class Logger {
         Logger.serializeArgument(arg)
       ).join(' ') : '';
       const logLine = `${timestamp} [${level}] ${message}${argsStr}\n`;
-      appendFileSync(Logger.logFile, logLine, 'utf8');
+      appendFileSync(Logger.logFile, logLine, { encoding: 'utf8', mode: 0o600 });
+      chmodSync(Logger.logFile, 0o600);
     } catch (error) {
       // Silently fail to avoid recursive logging issues
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -38,8 +38,8 @@ export class Logger {
         Logger.serializeArgument(arg)
       ).join(' ') : '';
       const logLine = `${timestamp} [${level}] ${message}${argsStr}\n`;
+      if (existsSync(Logger.logFile)) chmodSync(Logger.logFile, 0o600);
       appendFileSync(Logger.logFile, logLine, { encoding: 'utf8', mode: 0o600 });
-      chmodSync(Logger.logFile, 0o600);
     } catch (error) {
       // Silently fail to avoid recursive logging issues
     }

--- a/src/order-idempotency-store.ts
+++ b/src/order-idempotency-store.ts
@@ -1,5 +1,14 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
+import {
+  mkdir as fsMkdir,
+  chmod as fsChmod,
+  open as fsOpen,
+  readFile as fsReadFile,
+  rename as fsRename,
+  stat as fsStat,
+  unlink as fsUnlink,
+} from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import type { OrderRequest } from "./ib-client/types.js";
@@ -28,6 +37,38 @@ interface StoreDocument {
 
 const EMPTY_STORE: StoreDocument = { version: 1, records: {} };
 const LOCK_TIMEOUT_MS = 5_000;
+const LOCK_INITIALIZATION_GRACE_MS = 1_000;
+
+interface OrderStoreFileSystem {
+  chmod: typeof fsChmod;
+  mkdir: typeof fsMkdir;
+  open: typeof fsOpen;
+  readFile: typeof fsReadFile;
+  rename: typeof fsRename;
+  stat: typeof fsStat;
+  unlink: typeof fsUnlink;
+}
+
+export interface OrderIdempotencyStoreOptions {
+  fileSystem?: Partial<OrderStoreFileSystem>;
+  lockInitializationGraceMs?: number;
+}
+
+interface LockOwnership {
+  handle: FileHandle;
+  inode: number;
+  metadata: string;
+}
+
+const defaultFileSystem: OrderStoreFileSystem = {
+  chmod: fsChmod,
+  mkdir: fsMkdir,
+  open: fsOpen,
+  readFile: fsReadFile,
+  rename: fsRename,
+  stat: fsStat,
+  unlink: fsUnlink,
+};
 
 export class OrderIdempotencyConflictError extends Error {
   constructor(clientOrderId: string) {
@@ -67,10 +108,18 @@ export function defaultOrderIdempotencyStorePath(): string {
 export class OrderIdempotencyStore {
   readonly filePath: string;
   private readonly lockPath: string;
+  private readonly fileSystem: OrderStoreFileSystem;
+  private readonly lockInitializationGraceMs: number;
 
-  constructor(filePath = defaultOrderIdempotencyStorePath()) {
+  constructor(
+    filePath = defaultOrderIdempotencyStorePath(),
+    options: OrderIdempotencyStoreOptions = {},
+  ) {
     this.filePath = filePath;
     this.lockPath = `${filePath}.lock`;
+    this.fileSystem = { ...defaultFileSystem, ...options.fileSystem };
+    this.lockInitializationGraceMs = options.lockInitializationGraceMs
+      ?? LOCK_INITIALIZATION_GRACE_MS;
   }
 
   async reserve(order: OrderRequest): Promise<OrderReservation> {
@@ -135,7 +184,11 @@ export class OrderIdempotencyStore {
   private async withLock<T>(
     operation: (document: StoreDocument) => Promise<{ value: T; changed: boolean }>,
   ): Promise<T> {
-    await mkdir(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
+    await this.fileSystem.mkdir(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
+    await this.fileSystem.chmod(path.dirname(this.filePath), 0o700);
+    await this.fileSystem.chmod(this.filePath, 0o600).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    });
     const lock = await this.acquireLock();
     try {
       const document = await this.readDocument();
@@ -143,36 +196,35 @@ export class OrderIdempotencyStore {
       if (result.changed) await this.writeDocument(document);
       return result.value;
     } finally {
-      await lock.close();
-      await unlink(this.lockPath).catch(() => undefined);
+      await this.releaseLock(lock);
     }
   }
 
-  private async acquireLock() {
+  private async acquireLock(): Promise<LockOwnership> {
     const deadline = Date.now() + LOCK_TIMEOUT_MS;
     while (true) {
       try {
-        const handle = await open(this.lockPath, "wx", 0o600);
+        const handle = await this.fileSystem.open(this.lockPath, "wx", 0o600);
+        const inode = Number((await handle.stat()).ino);
+        const metadata = JSON.stringify({ pid: process.pid, token: randomUUID() });
         try {
-          await handle.writeFile(String(process.pid), "utf8");
+          await handle.writeFile(metadata, "utf8");
           await handle.sync();
-          return handle;
+          return { handle, inode, metadata };
         } catch (error) {
           await handle.close();
-          await unlink(this.lockPath).catch(() => undefined);
+          await this.unlinkOwnedInode(inode).catch(() => undefined);
           throw error;
         }
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
         try {
-          const ownerPid = Number.parseInt(await readFile(this.lockPath, "utf8"), 10);
-          if (Number.isInteger(ownerPid) && !this.isProcessAlive(ownerPid)) {
-            await unlink(this.lockPath);
+          if (await this.recoverAbandonedLock()) {
             continue;
           }
-        } catch (statError) {
-          if ((statError as NodeJS.ErrnoException).code === "ENOENT") continue;
-          throw statError;
+        } catch (recoveryError) {
+          if ((recoveryError as NodeJS.ErrnoException).code === "ENOENT") continue;
+          throw recoveryError;
         }
         if (Date.now() >= deadline) {
           throw new Error(`Timed out waiting for order store lock ${this.lockPath}`, { cause: error });
@@ -180,6 +232,52 @@ export class OrderIdempotencyStore {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
     }
+  }
+
+  private async recoverAbandonedLock(): Promise<boolean> {
+    const initialStat = await this.fileSystem.stat(this.lockPath);
+    if (Date.now() - initialStat.mtimeMs < this.lockInitializationGraceMs) return false;
+
+    const metadata = await this.fileSystem.readFile(this.lockPath, "utf8");
+    let owner: { pid?: unknown; token?: unknown } | undefined;
+    try {
+      owner = JSON.parse(metadata) as { pid?: unknown; token?: unknown };
+    } catch {
+      owner = undefined;
+    }
+    if (
+      owner
+      && Number.isInteger(owner.pid)
+      && typeof owner.token === "string"
+      && this.isProcessAlive(owner.pid as number)
+    ) {
+      return false;
+    }
+    return this.unlinkIfUnchanged(Number(initialStat.ino), metadata);
+  }
+
+  private async releaseLock(lock: LockOwnership): Promise<void> {
+    await lock.handle.close();
+    await this.unlinkIfUnchanged(lock.inode, lock.metadata);
+  }
+
+  private async unlinkIfUnchanged(expectedInode: number, expectedMetadata: string): Promise<boolean> {
+    const before = await this.fileSystem.stat(this.lockPath);
+    if (Number(before.ino) !== expectedInode) return false;
+    const metadata = await this.fileSystem.readFile(this.lockPath, "utf8");
+    const after = await this.fileSystem.stat(this.lockPath);
+    if (Number(after.ino) !== expectedInode || metadata !== expectedMetadata) return false;
+    await this.fileSystem.unlink(this.lockPath);
+    return true;
+  }
+
+  private async unlinkOwnedInode(expectedInode: number): Promise<boolean> {
+    const before = await this.fileSystem.stat(this.lockPath);
+    if (Number(before.ino) !== expectedInode) return false;
+    const after = await this.fileSystem.stat(this.lockPath);
+    if (Number(after.ino) !== expectedInode) return false;
+    await this.fileSystem.unlink(this.lockPath);
+    return true;
   }
 
   private isProcessAlive(pid: number): boolean {
@@ -193,7 +291,7 @@ export class OrderIdempotencyStore {
 
   private async readDocument(): Promise<StoreDocument> {
     try {
-      const parsed = JSON.parse(await readFile(this.filePath, "utf8")) as StoreDocument;
+      const parsed = JSON.parse(await this.fileSystem.readFile(this.filePath, "utf8")) as StoreDocument;
       if (parsed.version !== 1 || !parsed.records || typeof parsed.records !== "object") {
         throw new Error(`Invalid order idempotency store at ${this.filePath}`);
       }
@@ -208,18 +306,29 @@ export class OrderIdempotencyStore {
 
   private async writeDocument(document: StoreDocument): Promise<void> {
     const tempPath = `${this.filePath}.${process.pid}.${randomUUID()}.tmp`;
-    const handle = await open(tempPath, "wx", 0o600);
+    const handle = await this.fileSystem.open(tempPath, "wx", 0o600);
+    let renamed = false;
     try {
       await handle.writeFile(`${JSON.stringify(document, null, 2)}\n`, "utf8");
       await handle.sync();
-    } finally {
       await handle.close();
-    }
-    try {
-      await rename(tempPath, this.filePath);
+      await this.fileSystem.rename(tempPath, this.filePath);
+      renamed = true;
+      await this.fileSystem.chmod(this.filePath, 0o600);
+      await this.syncParentDirectory();
     } catch (error) {
-      await unlink(tempPath).catch(() => undefined);
+      await handle.close().catch(() => undefined);
+      if (!renamed) await this.fileSystem.unlink(tempPath).catch(() => undefined);
       throw error;
+    }
+  }
+
+  private async syncParentDirectory(): Promise<void> {
+    const directory = await this.fileSystem.open(path.dirname(this.filePath), "r");
+    try {
+      await directory.sync();
+    } finally {
+      await directory.close();
     }
   }
 }

--- a/src/order-idempotency-store.ts
+++ b/src/order-idempotency-store.ts
@@ -1,0 +1,225 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import type { OrderRequest } from "./ib-client/types.js";
+
+export type OrderIdempotencyState = "reserved" | "completed" | "uncertain";
+
+export interface OrderIdempotencyRecord {
+  clientOrderId: string;
+  fingerprint: string;
+  state: OrderIdempotencyState;
+  response?: unknown;
+  error?: unknown;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OrderReservation {
+  owner: boolean;
+  record: OrderIdempotencyRecord;
+}
+
+interface StoreDocument {
+  version: 1;
+  records: Record<string, OrderIdempotencyRecord>;
+}
+
+const EMPTY_STORE: StoreDocument = { version: 1, records: {} };
+const LOCK_TIMEOUT_MS = 5_000;
+
+export class OrderIdempotencyConflictError extends Error {
+  constructor(clientOrderId: string) {
+    super(`Client order ID ${clientOrderId} was already used for a different order`);
+    this.name = "OrderIdempotencyConflictError";
+  }
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalize(entry)]),
+    );
+  }
+  return value;
+}
+
+export function orderFingerprint(order: OrderRequest): string {
+  const normalized: OrderRequest = {
+    ...order,
+    symbol: order.symbol?.toUpperCase(),
+    exchange: order.exchange?.toUpperCase(),
+    tif: order.tif ?? "DAY",
+  };
+  return createHash("sha256").update(JSON.stringify(canonicalize(normalized))).digest("hex");
+}
+
+export function defaultOrderIdempotencyStorePath(): string {
+  return process.env.IB_ORDER_IDEMPOTENCY_STORE_PATH
+    || path.join(homedir(), ".interactive-brokers-mcp", "order-idempotency.json");
+}
+
+export class OrderIdempotencyStore {
+  readonly filePath: string;
+  private readonly lockPath: string;
+
+  constructor(filePath = defaultOrderIdempotencyStorePath()) {
+    this.filePath = filePath;
+    this.lockPath = `${filePath}.lock`;
+  }
+
+  async reserve(order: OrderRequest): Promise<OrderReservation> {
+    const fingerprint = orderFingerprint(order);
+    return this.withLock<OrderReservation>(async (document) => {
+      const existing = document.records[order.clientOrderId];
+      if (existing) {
+        if (existing.fingerprint !== fingerprint) {
+          throw new OrderIdempotencyConflictError(order.clientOrderId);
+        }
+        return { value: { owner: false, record: existing }, changed: false };
+      }
+
+      const timestamp = new Date().toISOString();
+      const record: OrderIdempotencyRecord = {
+        clientOrderId: order.clientOrderId,
+        fingerprint,
+        state: "reserved",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+      document.records[order.clientOrderId] = record;
+      return { value: { owner: true, record }, changed: true };
+    });
+  }
+
+  async recordResponse(order: OrderRequest, response: unknown): Promise<OrderIdempotencyRecord> {
+    return this.update(order, "completed", { response });
+  }
+
+  async recordUncertain(order: OrderRequest, error: unknown): Promise<OrderIdempotencyRecord> {
+    return this.update(order, "uncertain", { error });
+  }
+
+  async get(clientOrderId: string): Promise<OrderIdempotencyRecord | undefined> {
+    const document = await this.readDocument();
+    return document.records[clientOrderId];
+  }
+
+  private async update(
+    order: OrderRequest,
+    state: "completed" | "uncertain",
+    payload: { response?: unknown; error?: unknown },
+  ): Promise<OrderIdempotencyRecord> {
+    const fingerprint = orderFingerprint(order);
+    return this.withLock(async (document) => {
+      const existing = document.records[order.clientOrderId];
+      if (!existing || existing.fingerprint !== fingerprint) {
+        throw new OrderIdempotencyConflictError(order.clientOrderId);
+      }
+      const record: OrderIdempotencyRecord = {
+        ...existing,
+        state,
+        ...payload,
+        updatedAt: new Date().toISOString(),
+      };
+      document.records[order.clientOrderId] = record;
+      return { value: record, changed: true };
+    });
+  }
+
+  private async withLock<T>(
+    operation: (document: StoreDocument) => Promise<{ value: T; changed: boolean }>,
+  ): Promise<T> {
+    await mkdir(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
+    const lock = await this.acquireLock();
+    try {
+      const document = await this.readDocument();
+      const result = await operation(document);
+      if (result.changed) await this.writeDocument(document);
+      return result.value;
+    } finally {
+      await lock.close();
+      await unlink(this.lockPath).catch(() => undefined);
+    }
+  }
+
+  private async acquireLock() {
+    const deadline = Date.now() + LOCK_TIMEOUT_MS;
+    while (true) {
+      try {
+        const handle = await open(this.lockPath, "wx", 0o600);
+        try {
+          await handle.writeFile(String(process.pid), "utf8");
+          await handle.sync();
+          return handle;
+        } catch (error) {
+          await handle.close();
+          await unlink(this.lockPath).catch(() => undefined);
+          throw error;
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        try {
+          const ownerPid = Number.parseInt(await readFile(this.lockPath, "utf8"), 10);
+          if (Number.isInteger(ownerPid) && !this.isProcessAlive(ownerPid)) {
+            await unlink(this.lockPath);
+            continue;
+          }
+        } catch (statError) {
+          if ((statError as NodeJS.ErrnoException).code === "ENOENT") continue;
+          throw statError;
+        }
+        if (Date.now() >= deadline) {
+          throw new Error(`Timed out waiting for order store lock ${this.lockPath}`, { cause: error });
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    }
+  }
+
+  private isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code !== "ESRCH";
+    }
+  }
+
+  private async readDocument(): Promise<StoreDocument> {
+    try {
+      const parsed = JSON.parse(await readFile(this.filePath, "utf8")) as StoreDocument;
+      if (parsed.version !== 1 || !parsed.records || typeof parsed.records !== "object") {
+        throw new Error(`Invalid order idempotency store at ${this.filePath}`);
+      }
+      return parsed;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { version: EMPTY_STORE.version, records: {} };
+      }
+      throw error;
+    }
+  }
+
+  private async writeDocument(document: StoreDocument): Promise<void> {
+    const tempPath = `${this.filePath}.${process.pid}.${randomUUID()}.tmp`;
+    const handle = await open(tempPath, "wx", 0o600);
+    try {
+      await handle.writeFile(`${JSON.stringify(document, null, 2)}\n`, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    try {
+      await rename(tempPath, this.filePath);
+    } catch (error) {
+      await unlink(tempPath).catch(() => undefined);
+      throw error;
+    }
+  }
+}

--- a/src/order-idempotency-store.ts
+++ b/src/order-idempotency-store.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import {
   mkdir as fsMkdir,
   chmod as fsChmod,
+  link as fsLink,
   open as fsOpen,
   readFile as fsReadFile,
   rename as fsRename,
@@ -41,6 +42,7 @@ const LOCK_INITIALIZATION_GRACE_MS = 1_000;
 
 interface OrderStoreFileSystem {
   chmod: typeof fsChmod;
+  link: typeof fsLink;
   mkdir: typeof fsMkdir;
   open: typeof fsOpen;
   readFile: typeof fsReadFile;
@@ -55,13 +57,13 @@ export interface OrderIdempotencyStoreOptions {
 }
 
 interface LockOwnership {
-  handle: FileHandle;
   inode: number;
   metadata: string;
 }
 
 const defaultFileSystem: OrderStoreFileSystem = {
   chmod: fsChmod,
+  link: fsLink,
   mkdir: fsMkdir,
   open: fsOpen,
   readFile: fsReadFile,
@@ -159,6 +161,14 @@ export class OrderIdempotencyStore {
     return document.records[clientOrderId];
   }
 
+  async lookup(order: OrderRequest): Promise<OrderIdempotencyRecord | undefined> {
+    const existing = await this.get(order.clientOrderId);
+    if (existing && existing.fingerprint !== orderFingerprint(order)) {
+      throw new OrderIdempotencyConflictError(order.clientOrderId);
+    }
+    return existing;
+  }
+
   private async update(
     order: OrderRequest,
     state: "completed" | "uncertain",
@@ -203,35 +213,67 @@ export class OrderIdempotencyStore {
   private async acquireLock(): Promise<LockOwnership> {
     const deadline = Date.now() + LOCK_TIMEOUT_MS;
     while (true) {
+      let contentionError: unknown;
+      const token = randomUUID();
+      const ownerPath = `${this.lockPath}.${process.pid}.${token}.owner`;
+      const metadata = JSON.stringify({ pid: process.pid, token });
       try {
-        const handle = await this.fileSystem.open(this.lockPath, "wx", 0o600);
-        const inode = Number((await handle.stat()).ino);
-        const metadata = JSON.stringify({ pid: process.pid, token: randomUUID() });
+        const handle = await this.fileSystem.open(ownerPath, "wx", 0o600);
+        let ownerInode = 0;
         try {
-          await handle.writeFile(metadata, "utf8");
-          await handle.sync();
-          return { handle, inode, metadata };
+          await this.writeAndClose(handle, async () => {
+            await handle.writeFile(metadata, "utf8");
+            await handle.sync();
+            ownerInode = Number((await handle.stat()).ino);
+          });
         } catch (error) {
-          await handle.close();
-          await this.unlinkOwnedInode(inode).catch(() => undefined);
+          await this.fileSystem.unlink(ownerPath).catch(() => undefined);
           throw error;
+        }
+        try {
+          // hard-link publication is atomic: the canonical path is either absent or
+          // points at a fully written, fsynced owner metadata file.
+          await this.fileSystem.link(ownerPath, this.lockPath);
+          await this.fileSystem.unlink(ownerPath).catch(() => undefined);
+          return { inode: ownerInode, metadata };
+        } catch (error) {
+          await this.fileSystem.unlink(ownerPath).catch(() => undefined);
+          if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+          contentionError = error;
         }
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-        try {
-          if (await this.recoverAbandonedLock()) {
-            continue;
-          }
-        } catch (recoveryError) {
-          if ((recoveryError as NodeJS.ErrnoException).code === "ENOENT") continue;
-          throw recoveryError;
+        contentionError = error;
+      }
+      try {
+        if (await this.recoverAbandonedLock()) {
+          continue;
         }
-        if (Date.now() >= deadline) {
-          throw new Error(`Timed out waiting for order store lock ${this.lockPath}`, { cause: error });
-        }
-        await new Promise((resolve) => setTimeout(resolve, 10));
+      } catch (recoveryError) {
+        if ((recoveryError as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw recoveryError;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for order store lock ${this.lockPath}`, { cause: contentionError });
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+
+  private async writeAndClose(handle: FileHandle, write: () => Promise<void>): Promise<void> {
+    let primaryError: unknown;
+    try {
+      await write();
+    } catch (error) {
+      primaryError = error;
+    } finally {
+      try {
+        await handle.close();
+      } catch (closeError) {
+        if (primaryError === undefined) primaryError = closeError;
       }
     }
+    if (primaryError !== undefined) throw primaryError;
   }
 
   private async recoverAbandonedLock(): Promise<boolean> {
@@ -257,7 +299,6 @@ export class OrderIdempotencyStore {
   }
 
   private async releaseLock(lock: LockOwnership): Promise<void> {
-    await lock.handle.close();
     await this.unlinkIfUnchanged(lock.inode, lock.metadata);
   }
 
@@ -267,15 +308,6 @@ export class OrderIdempotencyStore {
     const metadata = await this.fileSystem.readFile(this.lockPath, "utf8");
     const after = await this.fileSystem.stat(this.lockPath);
     if (Number(after.ino) !== expectedInode || metadata !== expectedMetadata) return false;
-    await this.fileSystem.unlink(this.lockPath);
-    return true;
-  }
-
-  private async unlinkOwnedInode(expectedInode: number): Promise<boolean> {
-    const before = await this.fileSystem.stat(this.lockPath);
-    if (Number(before.ino) !== expectedInode) return false;
-    const after = await this.fileSystem.stat(this.lockPath);
-    if (Number(after.ino) !== expectedInode) return false;
     await this.fileSystem.unlink(this.lockPath);
     return true;
   }
@@ -309,15 +341,15 @@ export class OrderIdempotencyStore {
     const handle = await this.fileSystem.open(tempPath, "wx", 0o600);
     let renamed = false;
     try {
-      await handle.writeFile(`${JSON.stringify(document, null, 2)}\n`, "utf8");
-      await handle.sync();
-      await handle.close();
+      await this.writeAndClose(handle, async () => {
+        await handle.writeFile(`${JSON.stringify(document, null, 2)}\n`, "utf8");
+        await handle.sync();
+      });
       await this.fileSystem.rename(tempPath, this.filePath);
       renamed = true;
       await this.fileSystem.chmod(this.filePath, 0o600);
       await this.syncParentDirectory();
     } catch (error) {
-      await handle.close().catch(() => undefined);
       if (!renamed) await this.fileSystem.unlink(tempPath).catch(() => undefined);
       throw error;
     }

--- a/src/order-idempotency-store.ts
+++ b/src/order-idempotency-store.ts
@@ -59,6 +59,7 @@ export interface OrderIdempotencyStoreOptions {
 interface LockOwnership {
   inode: number;
   metadata: string;
+  ownerPath: string;
 }
 
 const defaultFileSystem: OrderStoreFileSystem = {
@@ -235,7 +236,7 @@ export class OrderIdempotencyStore {
           // points at a fully written, fsynced owner metadata file.
           await this.fileSystem.link(ownerPath, this.lockPath);
           await this.fileSystem.unlink(ownerPath).catch(() => undefined);
-          return { inode: ownerInode, metadata };
+          return { inode: ownerInode, metadata, ownerPath };
         } catch (error) {
           await this.fileSystem.unlink(ownerPath).catch(() => undefined);
           if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
@@ -299,7 +300,38 @@ export class OrderIdempotencyStore {
   }
 
   private async releaseLock(lock: LockOwnership): Promise<void> {
-    await this.unlinkIfUnchanged(lock.inode, lock.metadata);
+    let releaseError: unknown;
+    try {
+      await this.unlinkIfUnchanged(lock.inode, lock.metadata);
+    } catch (error) {
+      releaseError = error;
+    } finally {
+      try {
+        await this.unlinkAliasIfOwned(lock.ownerPath, lock.inode, lock.metadata);
+      } catch (aliasError) {
+        if (releaseError === undefined) releaseError = aliasError;
+      }
+    }
+    if (releaseError !== undefined) throw releaseError;
+  }
+
+  private async unlinkAliasIfOwned(
+    aliasPath: string,
+    expectedInode: number,
+    expectedMetadata: string,
+  ): Promise<boolean> {
+    try {
+      const before = await this.fileSystem.stat(aliasPath);
+      if (Number(before.ino) !== expectedInode) return false;
+      const metadata = await this.fileSystem.readFile(aliasPath, "utf8");
+      const after = await this.fileSystem.stat(aliasPath);
+      if (Number(after.ino) !== expectedInode || metadata !== expectedMetadata) return false;
+      await this.fileSystem.unlink(aliasPath);
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+      throw error;
+    }
   }
 
   private async unlinkIfUnchanged(expectedInode: number, expectedMetadata: string): Promise<boolean> {

--- a/src/order-idempotency-store.ts
+++ b/src/order-idempotency-store.ts
@@ -59,6 +59,7 @@ export interface OrderConfirmationReservation {
   owner: boolean;
   record: OrderIdempotencyRecord;
   attempt: OrderConfirmationAttempt;
+  authoritativeMessageIds: string[];
 }
 
 interface StoreDocument {
@@ -150,8 +151,13 @@ function canonicalize(value: unknown): unknown {
  * intentionally do not walk arbitrary object properties: an `id` buried in a
  * caller-controlled message/details object is not confirmation authority.
  */
-export function extractIbkrReplyIds(response: unknown): string[] {
-  if (Array.isArray(response)) return response.flatMap(extractIbkrReplyIds);
+interface IbkrWarningEvidence {
+  replyId: string;
+  messageIds: string[];
+}
+
+function extractIbkrWarningEvidence(response: unknown): IbkrWarningEvidence[] {
+  if (Array.isArray(response)) return response.flatMap(extractIbkrWarningEvidence);
   if (!response || typeof response !== "object") return [];
   const candidate = response as Record<string, unknown>;
   const hasDocumentedWarning = (
@@ -162,8 +168,15 @@ export function extractIbkrReplyIds(response: unknown): string[] {
     && candidate.messageIds.every((entry) => typeof entry === "string")
   );
   return typeof candidate.id === "string" && candidate.id.length > 0 && hasDocumentedWarning
-    ? [candidate.id]
+    ? [{
+      replyId: candidate.id,
+      messageIds: Array.isArray(candidate.messageIds) ? [...candidate.messageIds] as string[] : [],
+    }]
     : [];
+}
+
+export function extractIbkrReplyIds(response: unknown): string[] {
+  return extractIbkrWarningEvidence(response).map(({ replyId }) => replyId);
 }
 
 function brokerResponseFromEvidence(evidence: unknown): unknown {
@@ -171,22 +184,22 @@ function brokerResponseFromEvidence(evidence: unknown): unknown {
   return (evidence as Record<string, unknown>).brokerResponse;
 }
 
-function replyIdOccurrences(record: OrderIdempotencyRecord, replyId: string): number {
-  let count = record.replyIds
-    ? record.replyIds.filter((id) => id === replyId).length
-    : [record.response, brokerResponseFromEvidence(record.error)].reduce<number>(
-      (total, source) => total + extractIbkrReplyIds(source).filter((id) => id === replyId).length,
-      0,
-    );
+function warningEvidence(record: OrderIdempotencyRecord): IbkrWarningEvidence[] {
+  const evidence = [record.response, brokerResponseFromEvidence(record.error)]
+    .flatMap(extractIbkrWarningEvidence);
   for (const attempt of record.confirmations ?? []) {
-    const ids = attempt.replyIds ?? (
-      attempt.state === "completed"
-        ? extractIbkrReplyIds(attempt.response)
-        : extractIbkrReplyIds(brokerResponseFromEvidence(attempt.error))
-    );
-    count += ids.filter((id) => id === replyId).length;
+    if (attempt.state === "completed") evidence.push(...extractIbkrWarningEvidence(attempt.response));
+    if (attempt.state === "uncertain") {
+      evidence.push(...extractIbkrWarningEvidence(brokerResponseFromEvidence(attempt.error)));
+    }
   }
-  return count;
+  return evidence;
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  return leftSet.size === rightSet.size && [...leftSet].every((entry) => rightSet.has(entry));
 }
 
 export function orderFingerprint(order: OrderRequest): string {
@@ -275,26 +288,35 @@ export class OrderIdempotencyStore {
   async reserveConfirmation(
     accountId: string,
     replyId: string,
+    callerMessageIds?: string[],
   ): Promise<OrderConfirmationReservation> {
     return this.withLock<OrderConfirmationReservation>(async (document) => {
       const matches = Object.values(document.records)
-        .map((record) => ({ record, occurrences: replyIdOccurrences(record, replyId) }))
-        .filter(({ occurrences }) => occurrences > 0);
-      const totalOccurrences = matches.reduce((total, match) => total + match.occurrences, 0);
+        .flatMap((record) => warningEvidence(record)
+          .filter((evidence) => evidence.replyId === replyId)
+          .map((evidence) => ({ record, evidence })));
       if (
         matches.length !== 1
-        || totalOccurrences !== 1
         || matches[0].record.accountId !== accountId
       ) {
         throw new OrderConfirmationAuthorizationError(
           replyId,
-          totalOccurrences > 1 ? "ambiguous" : "not authorized",
+          matches.length > 1 ? "ambiguous" : "not authorized",
         );
       }
 
       const record = matches[0].record;
+      const authoritativeMessageIds = matches[0].evidence.messageIds;
+      if (callerMessageIds && !sameStringSet(callerMessageIds, authoritativeMessageIds)) {
+        throw new OrderConfirmationAuthorizationError(replyId, "messageIds mismatch with persisted warning evidence");
+      }
       const existing = record.confirmations?.find((attempt) => attempt.replyId === replyId);
-      if (existing) return { value: { owner: false, record, attempt: existing }, changed: false };
+      if (existing) {
+        return {
+          value: { owner: false, record, attempt: existing, authoritativeMessageIds },
+          changed: false,
+        };
+      }
 
       const timestamp = new Date().toISOString();
       const attempt: OrderConfirmationAttempt = {
@@ -305,7 +327,7 @@ export class OrderIdempotencyStore {
       };
       record.confirmations = [...(record.confirmations ?? []), attempt];
       record.updatedAt = timestamp;
-      return { value: { owner: true, record, attempt }, changed: true };
+      return { value: { owner: true, record, attempt, authoritativeMessageIds }, changed: true };
     });
   }
 

--- a/src/order-idempotency-store.ts
+++ b/src/order-idempotency-store.ts
@@ -1,4 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import {
   mkdir as fsMkdir,
   chmod as fsChmod,
@@ -15,13 +17,28 @@ import path from "node:path";
 import type { OrderRequest } from "./ib-client/types.js";
 
 export type OrderIdempotencyState = "reserved" | "completed" | "uncertain";
+export type OrderConfirmationState = "reserved" | "completed" | "uncertain";
+
+export interface OrderConfirmationAttempt {
+  replyId: string;
+  state: OrderConfirmationState;
+  replyIds?: string[];
+  response?: unknown;
+  error?: unknown;
+  createdAt: string;
+  updatedAt: string;
+}
 
 export interface OrderIdempotencyRecord {
   clientOrderId: string;
+  /** Missing on legacy records. Confirmation authorization must fail closed. */
+  accountId?: string;
   fingerprint: string;
   state: OrderIdempotencyState;
   response?: unknown;
   error?: unknown;
+  replyIds?: string[];
+  confirmations?: OrderConfirmationAttempt[];
   createdAt: string;
   updatedAt: string;
 }
@@ -29,6 +46,19 @@ export interface OrderIdempotencyRecord {
 export interface OrderReservation {
   owner: boolean;
   record: OrderIdempotencyRecord;
+}
+
+export class OrderConfirmationAuthorizationError extends Error {
+  constructor(replyId: string, reason = "not authorized") {
+    super(`IBKR reply ID ${replyId} is ${reason} for the allowlisted account`);
+    this.name = "OrderConfirmationAuthorizationError";
+  }
+}
+
+export interface OrderConfirmationReservation {
+  owner: boolean;
+  record: OrderIdempotencyRecord;
+  attempt: OrderConfirmationAttempt;
 }
 
 interface StoreDocument {
@@ -54,6 +84,7 @@ interface OrderStoreFileSystem {
 export interface OrderIdempotencyStoreOptions {
   fileSystem?: Partial<OrderStoreFileSystem>;
   lockInitializationGraceMs?: number;
+  processIdentity?: (pid: number) => string | undefined;
 }
 
 interface LockOwnership {
@@ -73,6 +104,27 @@ const defaultFileSystem: OrderStoreFileSystem = {
   unlink: fsUnlink,
 };
 
+function defaultProcessIdentity(pid: number): string | undefined {
+  try {
+    if (process.platform === "linux") {
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const fieldsAfterCommand = stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/);
+      const startTicks = fieldsAfterCommand[19];
+      return startTicks ? `linux:${startTicks}` : undefined;
+    }
+    if (process.platform === "darwin") {
+      const started = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      return started ? `darwin:${started}` : undefined;
+    }
+  } catch {
+    // Unsupported/vanished processes remain fail-closed in recovery.
+  }
+  return undefined;
+}
+
 export class OrderIdempotencyConflictError extends Error {
   constructor(clientOrderId: string) {
     super(`Client order ID ${clientOrderId} was already used for a different order`);
@@ -91,6 +143,50 @@ function canonicalize(value: unknown): unknown {
     );
   }
   return value;
+}
+
+/**
+ * Extract IBKR warning reply IDs only from response objects and arrays. We
+ * intentionally do not walk arbitrary object properties: an `id` buried in a
+ * caller-controlled message/details object is not confirmation authority.
+ */
+export function extractIbkrReplyIds(response: unknown): string[] {
+  if (Array.isArray(response)) return response.flatMap(extractIbkrReplyIds);
+  if (!response || typeof response !== "object") return [];
+  const candidate = response as Record<string, unknown>;
+  const hasDocumentedWarning = (
+    Array.isArray(candidate.message)
+    && candidate.message.every((entry) => typeof entry === "string")
+  ) || (
+    Array.isArray(candidate.messageIds)
+    && candidate.messageIds.every((entry) => typeof entry === "string")
+  );
+  return typeof candidate.id === "string" && candidate.id.length > 0 && hasDocumentedWarning
+    ? [candidate.id]
+    : [];
+}
+
+function brokerResponseFromEvidence(evidence: unknown): unknown {
+  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return undefined;
+  return (evidence as Record<string, unknown>).brokerResponse;
+}
+
+function replyIdOccurrences(record: OrderIdempotencyRecord, replyId: string): number {
+  let count = record.replyIds
+    ? record.replyIds.filter((id) => id === replyId).length
+    : [record.response, brokerResponseFromEvidence(record.error)].reduce<number>(
+      (total, source) => total + extractIbkrReplyIds(source).filter((id) => id === replyId).length,
+      0,
+    );
+  for (const attempt of record.confirmations ?? []) {
+    const ids = attempt.replyIds ?? (
+      attempt.state === "completed"
+        ? extractIbkrReplyIds(attempt.response)
+        : extractIbkrReplyIds(brokerResponseFromEvidence(attempt.error))
+    );
+    count += ids.filter((id) => id === replyId).length;
+  }
+  return count;
 }
 
 export function orderFingerprint(order: OrderRequest): string {
@@ -113,6 +209,7 @@ export class OrderIdempotencyStore {
   private readonly lockPath: string;
   private readonly fileSystem: OrderStoreFileSystem;
   private readonly lockInitializationGraceMs: number;
+  private readonly processIdentity: (pid: number) => string | undefined;
 
   constructor(
     filePath = defaultOrderIdempotencyStorePath(),
@@ -123,6 +220,7 @@ export class OrderIdempotencyStore {
     this.fileSystem = { ...defaultFileSystem, ...options.fileSystem };
     this.lockInitializationGraceMs = options.lockInitializationGraceMs
       ?? LOCK_INITIALIZATION_GRACE_MS;
+    this.processIdentity = options.processIdentity ?? defaultProcessIdentity;
   }
 
   async reserve(order: OrderRequest): Promise<OrderReservation> {
@@ -139,6 +237,7 @@ export class OrderIdempotencyStore {
       const timestamp = new Date().toISOString();
       const record: OrderIdempotencyRecord = {
         clientOrderId: order.clientOrderId,
+        accountId: order.accountId,
         fingerprint,
         state: "reserved",
         createdAt: timestamp,
@@ -150,11 +249,14 @@ export class OrderIdempotencyStore {
   }
 
   async recordResponse(order: OrderRequest, response: unknown): Promise<OrderIdempotencyRecord> {
-    return this.update(order, "completed", { response });
+    return this.update(order, "completed", { response, replyIds: extractIbkrReplyIds(response) });
   }
 
   async recordUncertain(order: OrderRequest, error: unknown): Promise<OrderIdempotencyRecord> {
-    return this.update(order, "uncertain", { error });
+    return this.update(order, "uncertain", {
+      error,
+      replyIds: extractIbkrReplyIds(brokerResponseFromEvidence(error)),
+    });
   }
 
   async get(clientOrderId: string): Promise<OrderIdempotencyRecord | undefined> {
@@ -170,10 +272,93 @@ export class OrderIdempotencyStore {
     return existing;
   }
 
+  async reserveConfirmation(
+    accountId: string,
+    replyId: string,
+  ): Promise<OrderConfirmationReservation> {
+    return this.withLock<OrderConfirmationReservation>(async (document) => {
+      const matches = Object.values(document.records)
+        .map((record) => ({ record, occurrences: replyIdOccurrences(record, replyId) }))
+        .filter(({ occurrences }) => occurrences > 0);
+      const totalOccurrences = matches.reduce((total, match) => total + match.occurrences, 0);
+      if (
+        matches.length !== 1
+        || totalOccurrences !== 1
+        || matches[0].record.accountId !== accountId
+      ) {
+        throw new OrderConfirmationAuthorizationError(
+          replyId,
+          totalOccurrences > 1 ? "ambiguous" : "not authorized",
+        );
+      }
+
+      const record = matches[0].record;
+      const existing = record.confirmations?.find((attempt) => attempt.replyId === replyId);
+      if (existing) return { value: { owner: false, record, attempt: existing }, changed: false };
+
+      const timestamp = new Date().toISOString();
+      const attempt: OrderConfirmationAttempt = {
+        replyId,
+        state: "reserved",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+      record.confirmations = [...(record.confirmations ?? []), attempt];
+      record.updatedAt = timestamp;
+      return { value: { owner: true, record, attempt }, changed: true };
+    });
+  }
+
+  async recordConfirmationResponse(
+    clientOrderId: string,
+    replyId: string,
+    response: unknown,
+  ): Promise<OrderIdempotencyRecord> {
+    return this.updateConfirmation(clientOrderId, replyId, "completed", {
+      response,
+      replyIds: extractIbkrReplyIds(response),
+    });
+  }
+
+  async recordConfirmationUncertain(
+    clientOrderId: string,
+    replyId: string,
+    error: unknown,
+  ): Promise<OrderIdempotencyRecord> {
+    return this.updateConfirmation(clientOrderId, replyId, "uncertain", {
+      error,
+      replyIds: extractIbkrReplyIds(brokerResponseFromEvidence(error)),
+    });
+  }
+
+  private async updateConfirmation(
+    clientOrderId: string,
+    replyId: string,
+    state: "completed" | "uncertain",
+    payload: { response?: unknown; error?: unknown; replyIds?: string[] },
+  ): Promise<OrderIdempotencyRecord> {
+    return this.withLock(async (document) => {
+      const record = document.records[clientOrderId];
+      const index = record?.confirmations?.findIndex((attempt) => attempt.replyId === replyId) ?? -1;
+      if (!record || index < 0 || record.confirmations![index].state !== "reserved") {
+        throw new OrderConfirmationAuthorizationError(replyId, "not in a reserved confirmation state");
+      }
+      const timestamp = new Date().toISOString();
+      record.confirmations![index] = {
+        ...record.confirmations![index],
+        state,
+        ...payload,
+        updatedAt: timestamp,
+      };
+      record.updatedAt = timestamp;
+      return { value: record, changed: true };
+    });
+  }
+
   private async update(
     order: OrderRequest,
     state: "completed" | "uncertain",
-    payload: { response?: unknown; error?: unknown },
+    payload: { response?: unknown; error?: unknown; replyIds?: string[] },
   ): Promise<OrderIdempotencyRecord> {
     const fingerprint = orderFingerprint(order);
     return this.withLock(async (document) => {
@@ -217,7 +402,8 @@ export class OrderIdempotencyStore {
       let contentionError: unknown;
       const token = randomUUID();
       const ownerPath = `${this.lockPath}.${process.pid}.${token}.owner`;
-      const metadata = JSON.stringify({ pid: process.pid, token });
+      const identity = this.processIdentity(process.pid);
+      const metadata = JSON.stringify({ pid: process.pid, token, ...(identity ? { identity } : {}) });
       try {
         const handle = await this.fileSystem.open(ownerPath, "wx", 0o600);
         let ownerInode = 0;
@@ -282,9 +468,9 @@ export class OrderIdempotencyStore {
     if (Date.now() - initialStat.mtimeMs < this.lockInitializationGraceMs) return false;
 
     const metadata = await this.fileSystem.readFile(this.lockPath, "utf8");
-    let owner: { pid?: unknown; token?: unknown } | undefined;
+    let owner: { pid?: unknown; token?: unknown; identity?: unknown } | undefined;
     try {
-      owner = JSON.parse(metadata) as { pid?: unknown; token?: unknown };
+      owner = JSON.parse(metadata) as { pid?: unknown; token?: unknown; identity?: unknown };
     } catch {
       owner = undefined;
     }
@@ -294,6 +480,12 @@ export class OrderIdempotencyStore {
       && typeof owner.token === "string"
       && this.isProcessAlive(owner.pid as number)
     ) {
+      if (typeof owner.identity === "string") {
+        const currentIdentity = this.processIdentity(owner.pid as number);
+        if (currentIdentity !== undefined && currentIdentity !== owner.identity) {
+          return this.unlinkIfUnchanged(Number(initialStat.ino), metadata);
+        }
+      }
       return false;
     }
     return this.unlinkIfUnchanged(Number(initialStat.ino), metadata);

--- a/src/order-policy.ts
+++ b/src/order-policy.ts
@@ -1,0 +1,39 @@
+import { PlaceOrderZodSchema, type PlaceOrderInput } from "./tool-definitions.js";
+import { parseReadOnlyMode } from "./config.js";
+
+export interface OrderPolicyConfig {
+  IB_READ_ONLY_MODE?: boolean | string;
+  IB_ALLOWED_ACCOUNT_ID?: string;
+}
+
+export class OrderPolicy {
+  readonly readOnly: boolean;
+  private readonly allowedAccountId?: string;
+
+  constructor(config: OrderPolicyConfig) {
+    this.readOnly = parseReadOnlyMode(config.IB_READ_ONLY_MODE);
+    this.allowedAccountId = config.IB_ALLOWED_ACCOUNT_ID?.trim() || undefined;
+  }
+
+  assertWriteEnabled(): void {
+    if (this.readOnly) {
+      throw new Error("Write operations are disabled in read-only mode");
+    }
+    if (!this.allowedAccountId) {
+      throw new Error("IB_ALLOWED_ACCOUNT_ID is required when IB_READ_ONLY_MODE is false");
+    }
+  }
+
+  assertAllowedAccount(accountId: string): void {
+    this.assertWriteEnabled();
+    if (accountId !== this.allowedAccountId) {
+      throw new Error(`Write operation account must match IB_ALLOWED_ACCOUNT_ID (${this.allowedAccountId})`);
+    }
+  }
+
+  validatePlaceOrder(input: unknown): PlaceOrderInput {
+    const order = PlaceOrderZodSchema.parse(input);
+    this.assertAllowedAccount(order.accountId);
+    return order;
+  }
+}

--- a/src/order-policy.ts
+++ b/src/order-policy.ts
@@ -33,6 +33,9 @@ export class OrderPolicy {
 
   validatePlaceOrder(input: unknown): PlaceOrderInput {
     const order = PlaceOrderZodSchema.parse(input);
+    if (!order.symbol && order.conid === undefined) {
+      throw new Error("Either symbol or conid is required");
+    }
     this.assertAllowedAccount(order.accountId);
     return order;
   }

--- a/src/order-policy.ts
+++ b/src/order-policy.ts
@@ -31,6 +31,11 @@ export class OrderPolicy {
     }
   }
 
+  getAllowedAccountId(): string {
+    this.assertWriteEnabled();
+    return this.allowedAccountId!;
+  }
+
   validatePlaceOrder(input: unknown): PlaceOrderInput {
     const order = PlaceOrderZodSchema.parse(input);
     if (!order.symbol && order.conid === undefined) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { IBGatewayManager } from "./gateway-manager.js";
 import { config } from "./config.js";
 import { registerTools } from "./tools.js";
 import { Logger } from "./logger.js";
+import { redactConfigForLogging } from "./cli-args.js";
 
 export const configSchema = z.object({
   // Authentication configuration
@@ -57,9 +58,7 @@ export function createIBMCPServer({ config: userConfig }: { config: z.infer<type
   };
 
   // Log the merged config for debugging (but redact sensitive info)
-  const logConfig = { ...mergedConfig };
-  if (logConfig.IB_PASSWORD_AUTH) logConfig.IB_PASSWORD_AUTH = '[REDACTED]';
-  if (logConfig.IB_PASSWORD) logConfig.IB_PASSWORD = '[REDACTED]';
+  const logConfig = redactConfigForLogging({ ...mergedConfig });
   Logger.info(`🔍 Final merged config: ${JSON.stringify(logConfig, null, 2)}`);
 
   // Create IB Client with default port initially - this will be updated once gateway starts
@@ -88,5 +87,4 @@ export function createIBMCPServer({ config: userConfig }: { config: z.infer<type
 
   return server;
 }
-
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ export const configSchema = z.object({
 
   // Read-only mode configuration
   IB_READ_ONLY_MODE: z.boolean().optional(),
+  IB_ALLOWED_ACCOUNT_ID: z.string().optional(),
 });
 
 // Global gateway manager instance
@@ -87,6 +88,5 @@ export function createIBMCPServer({ config: userConfig }: { config: z.infer<type
 
   return server;
 }
-
 
 

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -5,7 +5,6 @@ const IntegerOrStringIntegerZod = z.union([
   z.string().regex(/^[0-9]+(\.[0-9]+)?$/).transform((val) => parseFloat(val))
 ]);
 
-const SecurityTypeZod = z.enum(["STK", "OPT"]);
 const OptionRightZod = z.enum(["C", "P"]);
 
 export const AuthenticateZodShape = {
@@ -39,19 +38,14 @@ export const GetMarketDataZodShape = {
 };
 
 export const PlaceOrderZodShape = {
-  accountId: z.string(),
-  symbol: z.string().optional(),
+  clientOrderId: z.string().trim().min(1),
+  accountId: z.string().trim().min(1),
+  symbol: z.string().trim().min(1).optional(),
   conid: IntegerOrStringIntegerZod.optional(),
-  secType: SecurityTypeZod.optional(),
-  expiry: z.string().optional(),
-  strike: IntegerOrStringIntegerZod.optional(),
-  right: OptionRightZod.optional(),
   action: z.enum(["BUY", "SELL"]),
-  orderType: z.enum(["MKT", "LMT", "STP"]),
-  quantity: IntegerOrStringIntegerZod,
-  price: z.number().optional(),
-  stopPrice: z.number().optional(),
-  suppressConfirmations: z.boolean().optional(),
+  orderType: z.literal("LMT"),
+  quantity: IntegerOrStringIntegerZod.refine(Number.isFinite),
+  price: z.number().finite().positive(),
   exchange: z.string().optional(),
   tif: z.enum(["DAY", "GTC", "IOC", "OPG"]).optional()
 };
@@ -137,23 +131,8 @@ export const GetMarketDataZodSchema = z.object(GetMarketDataZodShape);
 
 export const PlaceOrderZodSchema = z
   .object(PlaceOrderZodShape)
+  .strict()
   .superRefine((data, ctx) => {
-    if (data.orderType === "LMT" && data.price === undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "LMT orders require price",
-        path: ["price"]
-      });
-    }
-
-    if (data.orderType === "STP" && data.stopPrice === undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "STP orders require stopPrice",
-        path: ["stopPrice"]
-      });
-    }
-
     if (!data.symbol && data.conid === undefined) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -162,36 +141,6 @@ export const PlaceOrderZodSchema = z
       });
     }
 
-    if (data.secType === "OPT" && data.conid === undefined) {
-      if (!data.symbol) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "OPT orders without conid require symbol",
-          path: ["symbol"]
-        });
-      }
-      if (!data.expiry) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "OPT orders without conid require expiry",
-          path: ["expiry"]
-        });
-      }
-      if (data.strike === undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "OPT orders without conid require strike",
-          path: ["strike"]
-        });
-      }
-      if (!data.right) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "OPT orders without conid require right",
-          path: ["right"]
-        });
-      }
-    }
   });
 
 export const GetOrderStatusZodSchema = z.object(GetOrderStatusZodShape);

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -129,19 +129,7 @@ export const GetOptionChainZodSchema = z.object(GetOptionChainZodShape);
 export const ResolveOptionConidZodSchema = z.object(ResolveOptionConidZodShape);
 export const GetMarketDataZodSchema = z.object(GetMarketDataZodShape);
 
-export const PlaceOrderZodSchema = z
-  .object(PlaceOrderZodShape)
-  .strict()
-  .superRefine((data, ctx) => {
-    if (!data.symbol && data.conid === undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Either symbol or conid is required",
-        path: ["symbol"]
-      });
-    }
-
-  });
+export const PlaceOrderZodSchema = z.object(PlaceOrderZodShape).strict();
 
 export const GetOrderStatusZodSchema = z.object(GetOrderStatusZodShape);
 export const GetLiveOrdersZodSchema = z.object(GetLiveOrdersZodShape);

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -63,6 +63,11 @@ export const ConfirmOrderZodShape = {
   messageIds: z.array(z.string())
 };
 
+export const CancelOrderZodShape = {
+  accountId: z.string().trim().min(1),
+  orderId: z.string().trim().min(1)
+};
+
 export const GetAlertsZodShape = {
   accountId: z.string()
 };
@@ -134,6 +139,7 @@ export const PlaceOrderZodSchema = z.object(PlaceOrderZodShape).strict();
 export const GetOrderStatusZodSchema = z.object(GetOrderStatusZodShape);
 export const GetLiveOrdersZodSchema = z.object(GetLiveOrdersZodShape);
 export const ConfirmOrderZodSchema = z.object(ConfirmOrderZodShape);
+export const CancelOrderZodSchema = z.object(CancelOrderZodShape).strict();
 export const GetAlertsZodSchema = z.object(GetAlertsZodShape);
 export const CreateAlertZodSchema = z.object(CreateAlertZodShape);
 export const ActivateAlertZodSchema = z.object(ActivateAlertZodShape);
@@ -152,6 +158,7 @@ export type PlaceOrderInput = z.infer<typeof PlaceOrderZodSchema>;
 export type GetOrderStatusInput = z.infer<typeof GetOrderStatusZodSchema>;
 export type GetLiveOrdersInput = z.infer<typeof GetLiveOrdersZodSchema>;
 export type ConfirmOrderInput = z.infer<typeof ConfirmOrderZodSchema>;
+export type CancelOrderInput = z.infer<typeof CancelOrderZodSchema>;
 export type GetAlertsInput = z.infer<typeof GetAlertsZodSchema>;
 export type CreateAlertInput = z.infer<typeof CreateAlertZodSchema>;
 export type ActivateAlertInput = z.infer<typeof ActivateAlertZodSchema>;

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -60,7 +60,9 @@ export const GetLiveOrdersZodShape = {
 
 export const ConfirmOrderZodShape = {
   replyId: z.string(),
-  messageIds: z.array(z.string())
+  // Retained as an optional compatibility echo. The handler derives the
+  // authoritative value from persisted IBKR warning evidence.
+  messageIds: z.array(z.string()).optional()
 };
 
 export const CancelOrderZodShape = {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -907,15 +907,64 @@ export class ToolHandlers {
       if (!auth.ok) {
         return auth.result;
       }
-      const result = await this.context.ibClient.confirmOrder(input.replyId, input.messageIds);
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      const reservation = await this.orderIdempotencyStore.reserveConfirmation(
+        this.orderPolicy.getAllowedAccountId(),
+        input.replyId,
+      );
+      if (!reservation.owner) {
+        return this.jsonResult({
+          code: "SUBMISSION_UNCERTAIN",
+          message: `IBKR reply ID ${input.replyId} was already attempted; do not automatically repeat it.`,
+          submissionUncertain: true,
+          confirmationAttempt: reservation.attempt,
+        });
+      }
+
+      let result: unknown;
+      try {
+        result = await this.context.ibClient.confirmOrder(input.replyId, input.messageIds);
+      } catch (error) {
+        const candidate = error && typeof error === "object"
+          ? error as Record<string, unknown>
+          : {};
+        const uncertain = {
+          code: "SUBMISSION_UNCERTAIN" as const,
+          message: `IBKR confirmation outcome is uncertain: ${error instanceof Error ? error.message : String(error)}`,
+          submissionUncertain: true,
+          status: typeof candidate.status === "number" ? candidate.status : undefined,
+          brokerResponse: candidate.ibkrBody,
+          transportCode: typeof candidate.transportCode === "string" ? candidate.transportCode : undefined,
+        };
+        await this.orderIdempotencyStore.recordConfirmationUncertain(
+          reservation.record.clientOrderId,
+          input.replyId,
+          uncertain,
+        ).catch(() => undefined);
+        return this.jsonResult(uncertain);
+      }
+
+      try {
+        await this.orderIdempotencyStore.recordConfirmationResponse(
+          reservation.record.clientOrderId,
+          input.replyId,
+          result,
+        );
+      } catch (persistenceError) {
+        const uncertain = {
+          code: "SUBMISSION_UNCERTAIN" as const,
+          message: "IBKR returned a confirmation response, but it could not be persisted. Reconcile manually and do not repeat the reply POST automatically.",
+          submissionUncertain: true,
+          brokerResponse: result,
+          persistenceError: this.persistenceErrorPayload(persistenceError),
+        };
+        await this.orderIdempotencyStore.recordConfirmationUncertain(
+          reservation.record.clientOrderId,
+          input.replyId,
+          uncertain,
+        ).catch(() => undefined);
+        return this.jsonResult(uncertain);
+      }
+      return this.jsonResult(result);
     } catch (error) {
       return {
         content: [

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -910,6 +910,7 @@ export class ToolHandlers {
       const reservation = await this.orderIdempotencyStore.reserveConfirmation(
         this.orderPolicy.getAllowedAccountId(),
         input.replyId,
+        input.messageIds,
       );
       if (!reservation.owner) {
         return this.jsonResult({
@@ -922,7 +923,10 @@ export class ToolHandlers {
 
       let result: unknown;
       try {
-        result = await this.context.ibClient.confirmOrder(input.replyId, input.messageIds);
+        result = await this.context.ibClient.confirmOrder(
+          input.replyId,
+          reservation.authoritativeMessageIds,
+        );
       } catch (error) {
         const candidate = error && typeof error === "object"
           ? error as Record<string, unknown>

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -7,6 +7,10 @@ import { FlexQueryClient } from "./flex-query-client.js";
 import { FlexQueryStorage } from "./flex-query-storage.js";
 import { OrderPolicy } from "./order-policy.js";
 import {
+  OrderIdempotencyStore,
+  type OrderIdempotencyRecord,
+} from "./order-idempotency-store.js";
+import {
   AuthenticateInput,
   GetAccountInfoInput,
   GetPositionsInput,
@@ -32,6 +36,7 @@ export interface ToolHandlerContext {
   config: any;
   flexQueryClient?: FlexQueryClient;
   flexQueryStorage?: FlexQueryStorage;
+  orderIdempotencyStore?: OrderIdempotencyStore;
 }
 
 type ToolHandlerResult = {
@@ -65,11 +70,14 @@ const MAX_FAILED_LOGINS = 5;
 export class ToolHandlers {
   private context: ToolHandlerContext;
   private readonly orderPolicy: OrderPolicy;
+  private readonly orderIdempotencyStore: OrderIdempotencyStore;
   private failedLogins = 0;
 
   constructor(context: ToolHandlerContext) {
     this.context = context;
     this.orderPolicy = new OrderPolicy(context.config);
+    this.orderIdempotencyStore = context.orderIdempotencyStore
+      ?? new OrderIdempotencyStore(context.config.IB_ORDER_IDEMPOTENCY_STORE_PATH || undefined);
     
     // Initialize flex query client and storage if token is provided
     // Only initialize if not already set (useful for testing)
@@ -397,6 +405,35 @@ export class ToolHandlers {
     return `Error: ${errorMessage}`;
   }
 
+  private orderSubmissionErrorPayload(error: unknown): {
+    code: "SUBMISSION_UNCERTAIN" | "ORDER_SUBMISSION_FAILED";
+    message: string;
+    status?: number;
+    ibkrBody?: unknown;
+    transportCode?: string;
+    submissionUncertain: boolean;
+  } | undefined {
+    if (!error || typeof error !== "object") return undefined;
+    const candidate = error as Record<string, unknown>;
+    if (candidate.name !== "OrderSubmissionError" && typeof candidate.submissionUncertain !== "boolean") {
+      return undefined;
+    }
+    const uncertain = candidate.submissionUncertain === true;
+    return {
+      code: uncertain ? "SUBMISSION_UNCERTAIN" : "ORDER_SUBMISSION_FAILED",
+      message: error instanceof Error ? error.message : "Order submission failed",
+      status: typeof candidate.status === "number" ? candidate.status : undefined,
+      ibkrBody: candidate.ibkrBody,
+      transportCode: typeof candidate.transportCode === "string" ? candidate.transportCode : undefined,
+      submissionUncertain: uncertain,
+    };
+  }
+
+  private replayOrderRecord(record: OrderIdempotencyRecord): ToolHandlerResult {
+    if (record.state === "completed") return this.jsonResult(record.response);
+    return this.jsonResult(record);
+  }
+
   async authenticate(input: AuthenticateInput): Promise<ToolHandlerResult> {
     try {
       // An explicit authenticate call is the caller asserting they have fixed whatever
@@ -701,12 +738,16 @@ export class ToolHandlers {
   }
 
   async placeOrder(input: PlaceOrderInput): Promise<ToolHandlerResult> {
+    let order: ReturnType<OrderPolicy["validatePlaceOrder"]> | undefined;
     try {
-      const order = this.orderPolicy.validatePlaceOrder(input);
+      order = this.orderPolicy.validatePlaceOrder(input);
       const auth = await this.ensureAuth();
       if (!auth.ok) {
         return auth.result;
       }
+      const reservation = await this.orderIdempotencyStore.reserve(order);
+      if (!reservation.owner) return this.replayOrderRecord(reservation.record);
+
       const result = await this.context.ibClient.placeOrder({
         clientOrderId: order.clientOrderId,
         accountId: order.accountId,
@@ -719,15 +760,18 @@ export class ToolHandlers {
         exchange: order.exchange,
         tif: order.tif,
       });
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-      };
+      await this.orderIdempotencyStore.recordResponse(order, result);
+      return this.jsonResult(result);
     } catch (error) {
+      const payload = this.orderSubmissionErrorPayload(error);
+      if (order && payload) {
+        if (payload.submissionUncertain) {
+          await this.orderIdempotencyStore.recordUncertain(order, payload);
+        } else {
+          await this.orderIdempotencyStore.recordResponse(order, payload);
+        }
+        return this.jsonResult(payload);
+      }
       return {
         content: [
           {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -443,6 +443,32 @@ export class ToolHandlers {
     });
   }
 
+  private persistenceErrorPayload(error: unknown): { name: string; message: string; code?: string } {
+    const candidate = error && typeof error === "object"
+      ? error as { name?: unknown; message?: unknown; code?: unknown }
+      : undefined;
+    return {
+      name: typeof candidate?.name === "string" ? candidate.name : "Error",
+      message: typeof candidate?.message === "string" ? candidate.message : String(error),
+      code: typeof candidate?.code === "string" ? candidate.code : undefined,
+    };
+  }
+
+  private uncertainPersistencePayload(brokerResponse: unknown, persistenceError: unknown) {
+    return {
+      code: "SUBMISSION_UNCERTAIN" as const,
+      message: "IBKR returned a response, but its terminal result could not be persisted. Check IBKR manually before taking any further action.",
+      submissionUncertain: true,
+      brokerResponse,
+      persistenceError: this.persistenceErrorPayload(persistenceError),
+      manualReconciliation: [
+        "Search IBKR live orders and executions for this clientOrderId.",
+        "Use brokerResponse to match the IBKR order or reply ID.",
+        "Do not submit a replacement order automatically.",
+      ],
+    };
+  }
+
   async authenticate(input: AuthenticateInput): Promise<ToolHandlerResult> {
     try {
       // An explicit authenticate call is the caller asserting they have fixed whatever
@@ -748,7 +774,6 @@ export class ToolHandlers {
 
   async placeOrder(input: PlaceOrderInput): Promise<ToolHandlerResult> {
     let order: ReturnType<OrderPolicy["validatePlaceOrder"]> | undefined;
-    let submissionAttempted = false;
     try {
       order = this.orderPolicy.validatePlaceOrder(input);
       const auth = await this.ensureAuth();
@@ -763,33 +788,32 @@ export class ToolHandlers {
       const reservation = await this.orderIdempotencyStore.reserve(order);
       if (!reservation.owner) return this.replayOrderRecord(reservation.record);
 
-      submissionAttempted = true;
-      const result = await this.context.ibClient.submitPreparedOrder(prepared);
-      await this.orderIdempotencyStore.recordResponse(order, result);
-      return this.jsonResult(result);
-    } catch (error) {
-      const payload = this.orderSubmissionErrorPayload(error);
-      if (order && payload) {
+      let result: unknown;
+      try {
+        result = await this.context.ibClient.submitPreparedOrder(prepared);
+      } catch (submissionError) {
+        const payload = this.orderSubmissionErrorPayload(submissionError) ?? {
+          code: "SUBMISSION_UNCERTAIN" as const,
+          message: `Order submission outcome is uncertain: ${submissionError instanceof Error ? submissionError.message : String(submissionError)}`,
+          submissionUncertain: true,
+        };
         if (payload.submissionUncertain) {
-          await this.orderIdempotencyStore.recordUncertain(order, payload);
+          await this.orderIdempotencyStore.recordUncertain(order, payload).catch(() => undefined);
         } else {
-          await this.orderIdempotencyStore.recordResponse(order, payload);
+          await this.orderIdempotencyStore.recordResponse(order, payload).catch(() => undefined);
         }
         return this.jsonResult(payload);
       }
-      if (order && submissionAttempted) {
-        const uncertain = {
-          code: "SUBMISSION_UNCERTAIN" as const,
-          message: `The order POST may have reached IBKR, but its terminal result could not be persisted: ${error instanceof Error ? error.message : String(error)}. Check IBKR manually before taking any further action.`,
-          submissionUncertain: true,
-          manualReconciliation: [
-            "Search IBKR live orders and executions for this clientOrderId.",
-            "Do not submit a replacement order automatically.",
-          ],
-        };
+
+      try {
+        await this.orderIdempotencyStore.recordResponse(order, result);
+      } catch (persistenceError) {
+        const uncertain = this.uncertainPersistencePayload(result, persistenceError);
         await this.orderIdempotencyStore.recordUncertain(order, uncertain).catch(() => undefined);
         return this.jsonResult(uncertain);
       }
+      return this.jsonResult(result);
+    } catch (error) {
       return {
         content: [
           {

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -5,6 +5,7 @@ import open from "open";
 import { Logger } from "./logger.js";
 import { FlexQueryClient } from "./flex-query-client.js";
 import { FlexQueryStorage } from "./flex-query-storage.js";
+import { OrderPolicy } from "./order-policy.js";
 import {
   AuthenticateInput,
   GetAccountInfoInput,
@@ -63,10 +64,12 @@ const MAX_FAILED_LOGINS = 5;
 
 export class ToolHandlers {
   private context: ToolHandlerContext;
+  private readonly orderPolicy: OrderPolicy;
   private failedLogins = 0;
 
   constructor(context: ToolHandlerContext) {
     this.context = context;
+    this.orderPolicy = new OrderPolicy(context.config);
     
     // Initialize flex query client and storage if token is provided
     // Only initialize if not already set (useful for testing)
@@ -698,27 +701,23 @@ export class ToolHandlers {
   }
 
   async placeOrder(input: PlaceOrderInput): Promise<ToolHandlerResult> {
-    const auth = await this.ensureAuth();
-    if (!auth.ok) {
-      return auth.result;
-    }
     try {
+      const order = this.orderPolicy.validatePlaceOrder(input);
+      const auth = await this.ensureAuth();
+      if (!auth.ok) {
+        return auth.result;
+      }
       const result = await this.context.ibClient.placeOrder({
-        accountId: input.accountId,
-        symbol: input.symbol,
-        conid: input.conid,
-        secType: input.secType,
-        expiry: input.expiry,
-        strike: input.strike,
-        right: input.right,
-        action: input.action,
-        orderType: input.orderType,
-        quantity: input.quantity, // Already converted by Zod schema
-        price: input.price,
-        stopPrice: input.stopPrice,
-        suppressConfirmations: input.suppressConfirmations,
-        exchange: input.exchange,
-        tif: input.tif,
+        clientOrderId: order.clientOrderId,
+        accountId: order.accountId,
+        symbol: order.symbol,
+        conid: order.conid,
+        action: order.action,
+        orderType: order.orderType,
+        quantity: order.quantity,
+        price: order.price,
+        exchange: order.exchange,
+        tif: order.tif,
       });
       return {
         content: [
@@ -796,11 +795,12 @@ export class ToolHandlers {
   }
 
   async confirmOrder(input: ConfirmOrderInput): Promise<ToolHandlerResult> {
-    const auth = await this.ensureAuth();
-    if (!auth.ok) {
-      return auth.result;
-    }
     try {
+      this.orderPolicy.assertWriteEnabled();
+      const auth = await this.ensureAuth();
+      if (!auth.ok) {
+        return auth.result;
+      }
       const result = await this.context.ibClient.confirmOrder(input.replyId, input.messageIds);
       return {
         content: [
@@ -850,11 +850,12 @@ export class ToolHandlers {
   }
 
   async createAlert(input: CreateAlertInput): Promise<ToolHandlerResult> {
-    const auth = await this.ensureAuth();
-    if (!auth.ok) {
-      return auth.result;
-    }
     try {
+      this.orderPolicy.assertAllowedAccount(input.accountId);
+      const auth = await this.ensureAuth();
+      if (!auth.ok) {
+        return auth.result;
+      }
       const result = await this.context.ibClient.createAlert(input.accountId, input.alertRequest);
       return {
         content: [
@@ -877,11 +878,12 @@ export class ToolHandlers {
   }
 
   async activateAlert(input: ActivateAlertInput): Promise<ToolHandlerResult> {
-    const auth = await this.ensureAuth();
-    if (!auth.ok) {
-      return auth.result;
-    }
     try {
+      this.orderPolicy.assertAllowedAccount(input.accountId);
+      const auth = await this.ensureAuth();
+      if (!auth.ok) {
+        return auth.result;
+      }
       const result = await this.context.ibClient.activateAlert(input.accountId, input.alertId);
       return {
         content: [
@@ -904,11 +906,12 @@ export class ToolHandlers {
   }
 
   async deleteAlert(input: DeleteAlertInput): Promise<ToolHandlerResult> {
-    const auth = await this.ensureAuth();
-    if (!auth.ok) {
-      return auth.result;
-    }
     try {
+      this.orderPolicy.assertAllowedAccount(input.accountId);
+      const auth = await this.ensureAuth();
+      if (!auth.ok) {
+        return auth.result;
+      }
       const result = await this.context.ibClient.deleteAlert(input.accountId, input.alertId);
       return {
         content: [

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -21,6 +21,7 @@ import {
   GetOrderStatusInput,
   GetLiveOrdersInput,
   ConfirmOrderInput,
+  CancelOrderInput,
   GetAlertsInput,
   CreateAlertInput,
   ActivateAlertInput,
@@ -426,6 +427,25 @@ export class ToolHandlers {
       ibkrBody: candidate.ibkrBody,
       transportCode: typeof candidate.transportCode === "string" ? candidate.transportCode : undefined,
       submissionUncertain: uncertain,
+    };
+  }
+
+  private orderCancellationErrorPayload(error: unknown): {
+    code: "ORDER_CANCELLATION_FAILED";
+    message: string;
+    status: number;
+    ibkrBody: unknown;
+  } | undefined {
+    if (!error || typeof error !== "object") return undefined;
+    const candidate = error as Record<string, unknown>;
+    if (candidate.name !== "OrderCancellationError" || typeof candidate.status !== "number") {
+      return undefined;
+    }
+    return {
+      code: "ORDER_CANCELLATION_FAILED",
+      message: error instanceof Error ? error.message : "Order cancellation failed",
+      status: candidate.status,
+      ibkrBody: candidate.ibkrBody,
     };
   }
 
@@ -905,6 +925,18 @@ export class ToolHandlers {
           },
         ],
       };
+    }
+  }
+
+  async cancelOrder(input: CancelOrderInput): Promise<ToolHandlerResult> {
+    try {
+      this.orderPolicy.assertAllowedAccount(input.accountId);
+      const auth = await this.ensureAuth();
+      if (!auth.ok) return auth.result;
+      return this.jsonResult(await this.context.ibClient.cancelOrder(input.accountId, input.orderId));
+    } catch (error) {
+      const structured = this.orderCancellationErrorPayload(error);
+      return structured ? this.jsonResult(structured) : this.textResult(this.formatError(error));
     }
   }
 

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -431,7 +431,16 @@ export class ToolHandlers {
 
   private replayOrderRecord(record: OrderIdempotencyRecord): ToolHandlerResult {
     if (record.state === "completed") return this.jsonResult(record.response);
-    return this.jsonResult(record);
+    return this.jsonResult({
+      code: "SUBMISSION_UNCERTAIN",
+      message: "This clientOrderId may already have been submitted. Check IBKR live orders and executions manually before taking any further action.",
+      submissionUncertain: true,
+      persistedRecord: record,
+      manualReconciliation: [
+        "Search IBKR live orders and executions for this clientOrderId.",
+        "Do not submit a replacement order automatically.",
+      ],
+    });
   }
 
   async authenticate(input: AuthenticateInput): Promise<ToolHandlerResult> {
@@ -739,27 +748,23 @@ export class ToolHandlers {
 
   async placeOrder(input: PlaceOrderInput): Promise<ToolHandlerResult> {
     let order: ReturnType<OrderPolicy["validatePlaceOrder"]> | undefined;
+    let submissionAttempted = false;
     try {
       order = this.orderPolicy.validatePlaceOrder(input);
       const auth = await this.ensureAuth();
       if (!auth.ok) {
         return auth.result;
       }
+      const existing = await this.orderIdempotencyStore.lookup(order);
+      if (existing) return this.replayOrderRecord(existing);
+      // Resolve and validate the contract before consuming the durable ID. The
+      // reservation is intentionally adjacent to the only side-effecting POST.
+      const prepared = await this.context.ibClient.prepareOrder(order);
       const reservation = await this.orderIdempotencyStore.reserve(order);
       if (!reservation.owner) return this.replayOrderRecord(reservation.record);
 
-      const result = await this.context.ibClient.placeOrder({
-        clientOrderId: order.clientOrderId,
-        accountId: order.accountId,
-        symbol: order.symbol,
-        conid: order.conid,
-        action: order.action,
-        orderType: order.orderType,
-        quantity: order.quantity,
-        price: order.price,
-        exchange: order.exchange,
-        tif: order.tif,
-      });
+      submissionAttempted = true;
+      const result = await this.context.ibClient.submitPreparedOrder(prepared);
       await this.orderIdempotencyStore.recordResponse(order, result);
       return this.jsonResult(result);
     } catch (error) {
@@ -771,6 +776,19 @@ export class ToolHandlers {
           await this.orderIdempotencyStore.recordResponse(order, payload);
         }
         return this.jsonResult(payload);
+      }
+      if (order && submissionAttempted) {
+        const uncertain = {
+          code: "SUBMISSION_UNCERTAIN" as const,
+          message: `The order POST may have reached IBKR, but its terminal result could not be persisted: ${error instanceof Error ? error.message : String(error)}. Check IBKR manually before taking any further action.`,
+          submissionUncertain: true,
+          manualReconciliation: [
+            "Search IBKR live orders and executions for this clientOrderId.",
+            "Do not submit a replacement order automatically.",
+          ],
+        };
+        await this.orderIdempotencyStore.recordUncertain(order, uncertain).catch(() => undefined);
+        return this.jsonResult(uncertain);
       }
       return {
         content: [

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -41,15 +41,14 @@ export function registerTools(
   };
 
   const handlers = new ToolHandlers(context);
-  // The SDK's generic registerTool signature recursively expands refined Zod
-  // effects beyond TypeScript's instantiation limit. Keep the runtime schema
-  // intact and narrow only the registration boundary.
+  // SDK type inference recursively expands transformed numeric fields beyond
+  // TypeScript's limit. This assertion changes only the registration type;
+  // the strict ZodObject is passed through unchanged at runtime.
   const registerPlaceOrder = server.registerTool.bind(server) as unknown as (
     name: string,
     config: { description: string; inputSchema: typeof PlaceOrderZodSchema },
     handler: (args: PlaceOrderInput) => ReturnType<ToolHandlers["placeOrder"]>,
   ) => unknown;
-
   const registerTool = (
     name: string,
     description: string,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -19,7 +19,8 @@ import {
   GetOrderStatusZodShape,
   GetPositionsZodShape,
   ListFlexQueriesZodShape,
-  PlaceOrderZodShape,
+  PlaceOrderZodSchema,
+  type PlaceOrderInput,
   ResolveOptionConidZodShape,
 } from "./tool-definitions.js";
 
@@ -40,6 +41,14 @@ export function registerTools(
   };
 
   const handlers = new ToolHandlers(context);
+  // The SDK's generic registerTool signature recursively expands refined Zod
+  // effects beyond TypeScript's instantiation limit. Keep the runtime schema
+  // intact and narrow only the registration boundary.
+  const registerPlaceOrder = server.registerTool.bind(server) as unknown as (
+    name: string,
+    config: { description: string; inputSchema: typeof PlaceOrderZodSchema },
+    handler: (args: PlaceOrderInput) => ReturnType<ToolHandlers["placeOrder"]>,
+  ) => unknown;
 
   const registerTool = (
     name: string,
@@ -93,10 +102,12 @@ export function registerTools(
   );
 
   if (writeEnabled) {
-    registerTool(
+    registerPlaceOrder(
       "place_order",
-      "Place a limit stock order. Usage: `{ \"clientOrderId\":\"unique-id\",\"accountId\":\"abc\",\"symbol\":\"AAPL\",\"action\":\"BUY\",\"orderType\":\"LMT\",\"quantity\":1,\"price\":185.5 }`.",
-      PlaceOrderZodShape,
+      {
+        description: "Place a limit stock order. The symbol or conid must resolve unambiguously to an authoritative STK contract. Usage: `{ \"clientOrderId\":\"unique-id\",\"accountId\":\"abc\",\"symbol\":\"AAPL\",\"action\":\"BUY\",\"orderType\":\"LMT\",\"quantity\":1,\"price\":185.5 }`.",
+        inputSchema: PlaceOrderZodSchema,
+      },
       async (args) => await handlers.placeOrder(args),
     );
   }
@@ -111,7 +122,7 @@ export function registerTools(
   registerTool(
     "get_live_orders",
     "Get all live/open orders for monitoring and validation. Usage: `{}` for all accounts or `{ \"accountId\": \"<id>\" }` for a specific account. " +
-      "This is the recommended way to validate that market orders were executed successfully after placing them.",
+      "Use this to monitor and validate submitted limit orders.",
     GetLiveOrdersZodShape,
     async (args) => await handlers.getLiveOrders(args),
   );

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -7,7 +7,8 @@ import {
   ActivateAlertZodShape,
   AuthenticateZodShape,
   ConfirmOrderZodShape,
-  CancelOrderZodShape,
+  CancelOrderZodSchema,
+  type CancelOrderInput,
   CreateAlertZodShape,
   DeleteAlertZodShape,
   ForgetFlexQueryZodShape,
@@ -49,6 +50,11 @@ export function registerTools(
     name: string,
     config: { description: string; inputSchema: typeof PlaceOrderZodSchema },
     handler: (args: PlaceOrderInput) => ReturnType<ToolHandlers["placeOrder"]>,
+  ) => unknown;
+  const registerCancelOrder = server.registerTool.bind(server) as unknown as (
+    name: string,
+    config: { description: string; inputSchema: typeof CancelOrderZodSchema },
+    handler: (args: CancelOrderInput) => ReturnType<ToolHandlers["cancelOrder"]>,
   ) => unknown;
   const registerTool = (
     name: string,
@@ -134,10 +140,12 @@ export function registerTools(
       ConfirmOrderZodShape,
       async (args) => await handlers.confirmOrder(args),
     );
-    registerTool(
+    registerCancelOrder(
       "cancel_order",
-      "Cancel a specific order in the allowlisted account. Verify the returned broker response and then check live orders. Usage: `{ \"accountId\": \"U12345\", \"orderId\": \"12345\" }`.",
-      CancelOrderZodShape,
+      {
+        description: "Cancel a specific order in the allowlisted account. Verify the returned broker response and then check live orders. Usage: `{ \"accountId\": \"U12345\", \"orderId\": \"12345\" }`.",
+        inputSchema: CancelOrderZodSchema,
+      },
       async (args) => await handlers.cancelOrder(args),
     );
   }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -136,7 +136,7 @@ export function registerTools(
   if (writeEnabled) {
     registerTool(
       "confirm_order",
-      "Manually confirm an order that requires confirmation. Usage: `{ \"replyId\": \"742a95a7-55f6-4d67-861b-2fd3e2b61e3c\", \"messageIds\": [\"o10151\", \"o10153\"] }`.",
+      "Manually confirm a persisted IBKR warning for the allowlisted account. messageIds are derived from durable broker evidence; an optional caller echo must match that set. Usage: `{ \"replyId\": \"742a95a7-55f6-4d67-861b-2fd3e2b61e3c\" }`.",
       ConfirmOrderZodShape,
       async (args) => await handlers.confirmOrder(args),
     );

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { IBClient } from "./ib-client.js";
 import { IBGatewayManager } from "./gateway-manager.js";
 import { ToolHandlers, type ToolHandlerContext } from "./tool-handlers.js";
+import { OrderPolicy } from "./order-policy.js";
 import {
   ActivateAlertZodShape,
   AuthenticateZodShape,
@@ -28,10 +29,14 @@ export function registerTools(
   gatewayManager?: IBGatewayManager,
   userConfig?: any,
 ) {
+  const orderPolicy = new OrderPolicy(userConfig ?? {});
+  if (!orderPolicy.readOnly) orderPolicy.assertWriteEnabled();
+  const writeEnabled = !orderPolicy.readOnly;
+
   const context: ToolHandlerContext = {
     ibClient,
     gatewayManager,
-    config: userConfig,
+    config: userConfig ?? {},
   };
 
   const handlers = new ToolHandlers(context);
@@ -87,16 +92,10 @@ export function registerTools(
     async (args) => await handlers.getMarketData(args),
   );
 
-  if (!userConfig?.IB_READ_ONLY_MODE) {
+  if (writeEnabled) {
     registerTool(
       "place_order",
-      "Place a trading order. Examples:\n" +
-        "- Market buy: `{ \"accountId\":\"abc\",\"symbol\":\"AAPL\",\"action\":\"BUY\",\"orderType\":\"MKT\",\"quantity\":1 }`\n" +
-        "- Limit sell: `{ \"accountId\":\"abc\",\"symbol\":\"AAPL\",\"action\":\"SELL\",\"orderType\":\"LMT\",\"quantity\":1,\"price\":185.5 }`\n" +
-        "- Stop sell: `{ \"accountId\":\"abc\",\"symbol\":\"AAPL\",\"action\":\"SELL\",\"orderType\":\"STP\",\"quantity\":1,\"stopPrice\":180 }`\n" +
-        "- Option buy: `{ \"accountId\":\"abc\",\"symbol\":\"AAPL\",\"secType\":\"OPT\",\"expiry\":\"JAN27\",\"strike\":200,\"right\":\"C\",\"action\":\"BUY\",\"orderType\":\"LMT\",\"quantity\":1,\"price\":4.5 }`\n" +
-        "- Option by conid: `{ \"accountId\":\"abc\",\"conid\":123456789,\"secType\":\"OPT\",\"action\":\"BUY\",\"orderType\":\"MKT\",\"quantity\":1 }`\n" +
-        "- Suppress confirmations: `{ \"accountId\":\"abc\",\"symbol\":\"AAPL\",\"action\":\"BUY\",\"orderType\":\"MKT\",\"quantity\":1,\"suppressConfirmations\":true }`",
+      "Place a limit stock order. Usage: `{ \"clientOrderId\":\"unique-id\",\"accountId\":\"abc\",\"symbol\":\"AAPL\",\"action\":\"BUY\",\"orderType\":\"LMT\",\"quantity\":1,\"price\":185.5 }`.",
       PlaceOrderZodShape,
       async (args) => await handlers.placeOrder(args),
     );
@@ -117,7 +116,7 @@ export function registerTools(
     async (args) => await handlers.getLiveOrders(args),
   );
 
-  if (!userConfig?.IB_READ_ONLY_MODE) {
+  if (writeEnabled) {
     registerTool(
       "confirm_order",
       "Manually confirm an order that requires confirmation. Usage: `{ \"replyId\": \"742a95a7-55f6-4d67-861b-2fd3e2b61e3c\", \"messageIds\": [\"o10151\", \"o10153\"] }`.",
@@ -133,7 +132,7 @@ export function registerTools(
     async (args) => await handlers.getAlerts(args),
   );
 
-  if (!userConfig?.IB_READ_ONLY_MODE) {
+  if (writeEnabled) {
     registerTool(
       "create_alert",
       "Create a new trading alert. Usage: `{ \"accountId\": \"<id>\", \"alertRequest\": { \"alertName\": \"Price Alert\", \"conditions\": [{ \"conidex\": \"265598\", \"type\": \"price\", \"operator\": \">\", \"triggerMethod\": \"last\", \"value\": \"150\" }] } }`.",
@@ -142,7 +141,7 @@ export function registerTools(
     );
   }
 
-  if (!userConfig?.IB_READ_ONLY_MODE) {
+  if (writeEnabled) {
     registerTool(
       "activate_alert",
       "Activate a previously created alert. Usage: `{ \"accountId\": \"<id>\", \"alertId\": \"<alertId>\" }`.",
@@ -151,7 +150,7 @@ export function registerTools(
     );
   }
 
-  if (!userConfig?.IB_READ_ONLY_MODE) {
+  if (writeEnabled) {
     registerTool(
       "delete_alert",
       "Delete an alert. Usage: `{ \"accountId\": \"<id>\", \"alertId\": \"<alertId>\" }`.",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -7,6 +7,7 @@ import {
   ActivateAlertZodShape,
   AuthenticateZodShape,
   ConfirmOrderZodShape,
+  CancelOrderZodShape,
   CreateAlertZodShape,
   DeleteAlertZodShape,
   ForgetFlexQueryZodShape,
@@ -132,6 +133,12 @@ export function registerTools(
       "Manually confirm an order that requires confirmation. Usage: `{ \"replyId\": \"742a95a7-55f6-4d67-861b-2fd3e2b61e3c\", \"messageIds\": [\"o10151\", \"o10153\"] }`.",
       ConfirmOrderZodShape,
       async (args) => await handlers.confirmOrder(args),
+    );
+    registerTool(
+      "cancel_order",
+      "Cancel a specific order in the allowlisted account. Verify the returned broker response and then check live orders. Usage: `{ \"accountId\": \"U12345\", \"orderId\": \"12345\" }`.",
+      CancelOrderZodShape,
+      async (args) => await handlers.cancelOrder(args),
     );
   }
 

--- a/test/README.md
+++ b/test/README.md
@@ -25,7 +25,7 @@ Global test setup file that configures the test environment, mocks, and cleanup.
 
 ### `test/tool-definitions.test.ts`
 Tests for Zod schemas and validation:
-- Order validation (market, limit, stop orders)
+- Order validation (strict allowlisted limit-stock orders)
 - Fractional share quantity support
 - Required field validation
 - Schema refinements
@@ -69,4 +69,3 @@ When adding new features:
 2. Add tests for IBClient methods in `ib-client.test.ts`
 3. Add tests for tool handlers in `tool-handlers.test.ts`
 4. Ensure all tests pass before committing: `npm test`
-

--- a/test/cli-args-security.test.ts
+++ b/test/cli-args-security.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseCliArgs, redactConfigForLogging, sanitizeCliArguments } from "../src/cli-args.js";
+
+const dirs: string[] = [];
+afterEach(async () => Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true }))));
+
+describe("CLI argument parsing and logging", () => {
+  it("parses read-only and account settings in space and equals forms", () => {
+    expect(parseCliArgs(["--ib-read-only-mode", "false", "--ib-allowed-account-id", "U12345"]))
+      .toMatchObject({ IB_READ_ONLY_MODE: false, IB_ALLOWED_ACCOUNT_ID: "U12345" });
+    expect(parseCliArgs(["--ib-read-only-mode=false", "--ib-allowed-account-id=U67890"]))
+      .toMatchObject({ IB_READ_ONLY_MODE: false, IB_ALLOWED_ACCOUNT_ID: "U67890" });
+  });
+
+  it("redacts every credential form, including username, TOTP and flex token", () => {
+    const secrets = ["USERVALUE_923", "PASSVALUE_923", "AUTHVALUE_923", "TOTPVALUE_923", "FLEXVALUE_923"];
+    const sanitized = sanitizeCliArguments([
+      "--ib-username", secrets[0],
+      `--ib-password=${secrets[1]}`,
+      "--ib-password-auth", secrets[2],
+      `--ib-totp-secret=${secrets[3]}`,
+      "--ib-flex-token", secrets[4],
+    ]);
+    const serialized = JSON.stringify(sanitized);
+    for (const secret of secrets) expect(serialized).not.toContain(secret);
+    expect(serialized.match(/\[REDACTED\]/g)).toHaveLength(5);
+  });
+
+  it("redacts nested authentication configuration consistently", () => {
+    const redacted = redactConfigForLogging({
+      username: "PRIVATE_USER",
+      password: "PRIVATE_PASSWORD",
+      totpSecret: "PRIVATE_TOTP",
+      nested: { flexToken: "PRIVATE_FLEX", safe: "visible" },
+    });
+    expect(redacted).toEqual({
+      username: "[REDACTED]",
+      password: "[REDACTED]",
+      totpSecret: "[REDACTED]",
+      nested: { flexToken: "[REDACTED]", safe: "visible" },
+    });
+  });
+
+  it("never writes CLI secrets to the real startup log", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ib-mcp-cli-log-"));
+    dirs.push(root);
+    const secrets = ["SPACE_USER_VALUE_923", "EQUAL_PASSWORD_VALUE_923", "TOTP_VALUE_923", "FLEX_VALUE_923"];
+    const script = [
+      "const { parseCliArgs } = await import('./src/cli-args.ts');",
+      `parseCliArgs(${JSON.stringify([
+        "--ib-username", secrets[0],
+        `--ib-password-auth=${secrets[1]}`,
+        "--ib-totp-secret", secrets[2],
+        `--ib-flex-token=${secrets[3]}`,
+        "--ib-read-only-mode=false",
+        "--ib-allowed-account-id=U12345",
+      ])});`,
+    ].join("\n");
+    const child = spawn(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
+      cwd: process.cwd(),
+      env: { ...process.env, IB_MCP_LOG_DIR: root, IB_MCP_CONSOLE_LOGGING: "false" },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    expect(await new Promise<number | null>((resolve) => child.once("exit", resolve))).toBe(0);
+    const log = await readFile(path.join(root, "ib-mcp.log"), "utf8");
+    for (const secret of secrets) expect(log).not.toContain(secret);
+    expect(log).toContain("[REDACTED]");
+  });
+});

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -517,10 +517,13 @@ describe('IBClient', () => {
       });
 
       it('should reject ambiguous stock symbol search results', async () => {
-        mockFetch.mockResolvedValueOnce(mockResponse([
-          { conid: 265598, symbol: 'ABC', sections: [{ secType: 'STK' }] },
-          { conid: 765432, symbol: 'ABC', sections: [{ secType: 'STK' }] },
-        ]));
+        mockFetch
+          .mockResolvedValueOnce(mockResponse([
+            { conid: 265598, symbol: 'ABC', sections: [{ secType: 'STK' }] },
+            { conid: 765432, symbol: 'ABC', sections: [{ secType: 'STK' }] },
+          ]))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'ABC', secType: 'STK' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 765432, symbol: 'ABC', secType: 'STK' }));
 
         await expect(client.placeOrder({
           clientOrderId: 'codex-ambiguous-symbol',
@@ -535,10 +538,36 @@ describe('IBClient', () => {
         expect(findCall('/iserver/account/U12345/orders')).toBeUndefined();
       });
 
+      it('should reject ambiguity revealed only by authoritative metadata', async () => {
+        mockFetch
+          .mockResolvedValueOnce(mockResponse([
+            { conid: 265598, symbol: 'ABC', sections: [{ secType: 'STK' }] },
+            { conid: 765432, symbol: 'ABC', sections: [{ secType: 'OPT' }] },
+          ]))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'ABC', secType: 'STK' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 765432, symbol: 'ABC', secType: 'STK' }));
+
+        await expect(client.placeOrder({
+          clientOrderId: 'codex-authoritative-ambiguity',
+          accountId: 'U12345',
+          symbol: 'ABC',
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 10,
+        })).rejects.toThrow(/ambiguous|stock/i);
+
+        expect(findCall('/iserver/contract/265598/info')).toBeDefined();
+        expect(findCall('/iserver/contract/765432/info')).toBeDefined();
+        expect(findCall('/iserver/account/U12345/orders')).toBeUndefined();
+      });
+
       it('should reject non-stock symbol search results', async () => {
-        mockFetch.mockResolvedValueOnce(mockResponse([
-          { conid: 912345678, symbol: 'AAPL', sections: [{ secType: 'OPT' }] },
-        ]));
+        mockFetch
+          .mockResolvedValueOnce(mockResponse([
+            { conid: 912345678, symbol: 'AAPL', sections: [{ secType: 'OPT' }] },
+          ]))
+          .mockResolvedValueOnce(mockResponse({ conid: 912345678, symbol: 'AAPL', secType: 'OPT' }));
 
         await expect(client.placeOrder({
           clientOrderId: 'codex-non-stock-symbol',

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -47,6 +47,7 @@ describe('IBClient', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetch.mockReset();
     vi.stubGlobal('fetch', mockFetch);
     mockFetch.mockResolvedValue(mockResponse({}));
     mockFs.existsSync.mockImplementation((target: unknown) =>
@@ -324,7 +325,8 @@ describe('IBClient', () => {
     describe('placeOrder', () => {
       it('should place limit order successfully', async () => {
         mockFetch
-          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
+          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123', status: 'Submitted' }]));
 
         const orderRequest = {
@@ -351,7 +353,8 @@ describe('IBClient', () => {
 
       it('should include price for limit orders', async () => {
         mockFetch
-          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
+          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -372,7 +375,8 @@ describe('IBClient', () => {
 
       it('should default tif to DAY when not specified', async () => {
         mockFetch
-          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
+          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -391,7 +395,8 @@ describe('IBClient', () => {
 
       it('should use the user-provided tif when given', async () => {
         mockFetch
-          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
+          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -411,7 +416,8 @@ describe('IBClient', () => {
 
       it('should include exchange in secdef/search URL when provided', async () => {
         mockFetch
-          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
+          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -433,7 +439,8 @@ describe('IBClient', () => {
 
       it('should include exchange in the order payload when specified', async () => {
         mockFetch
-          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
+          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -469,7 +476,8 @@ describe('IBClient', () => {
 
       it('should include the client order ID for limit orders', async () => {
         mockFetch
-          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
+          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -486,6 +494,63 @@ describe('IBClient', () => {
         expect(body.orders[0]).toEqual(expect.objectContaining({
           cOID: 'codex-20260716-001',
         }));
+      });
+
+      it('should reject an option conid using authoritative contract metadata', async () => {
+        mockFetch.mockResolvedValueOnce(mockResponse({
+          conid: 912345678,
+          symbol: 'AAPL',
+          secType: 'OPT',
+        }));
+
+        await expect(client.placeOrder({
+          clientOrderId: 'codex-option-conid',
+          accountId: 'U12345',
+          conid: 912345678,
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 4.5,
+        })).rejects.toThrow(/stock|STK/i);
+
+        expect(findCall('/iserver/account/U12345/orders')).toBeUndefined();
+      });
+
+      it('should reject ambiguous stock symbol search results', async () => {
+        mockFetch.mockResolvedValueOnce(mockResponse([
+          { conid: 265598, symbol: 'ABC', sections: [{ secType: 'STK' }] },
+          { conid: 765432, symbol: 'ABC', sections: [{ secType: 'STK' }] },
+        ]));
+
+        await expect(client.placeOrder({
+          clientOrderId: 'codex-ambiguous-symbol',
+          accountId: 'U12345',
+          symbol: 'ABC',
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 10,
+        })).rejects.toThrow(/ambiguous|stock/i);
+
+        expect(findCall('/iserver/account/U12345/orders')).toBeUndefined();
+      });
+
+      it('should reject non-stock symbol search results', async () => {
+        mockFetch.mockResolvedValueOnce(mockResponse([
+          { conid: 912345678, symbol: 'AAPL', sections: [{ secType: 'OPT' }] },
+        ]));
+
+        await expect(client.placeOrder({
+          clientOrderId: 'codex-non-stock-symbol',
+          accountId: 'U12345',
+          symbol: 'AAPL',
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 4.5,
+        })).rejects.toThrow(/stock|STK/i);
+
+        expect(findCall('/iserver/account/U12345/orders')).toBeUndefined();
       });
     });
 

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -1,6 +1,6 @@
 // test/ib-client.test.ts
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { IBClient, OrderCancellationError, OrderSubmissionError, SymbolNotFoundError } from '../src/ib-client.js';
+import { IBClient, OrderCancellationError, OrderConfirmationError, OrderSubmissionError, SymbolNotFoundError } from '../src/ib-client.js';
 
 const { mockSpawn, mockFs } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
@@ -921,6 +921,30 @@ describe('IBClient', () => {
         const body = JSON.parse(call![1].body);
         expect(body).toEqual({ confirmed: true, messageIds: ['msg1', 'msg2'] });
         expect(result).toEqual(mockResult);
+      });
+
+      it.each([400, 503])('preserves HTTP %s confirmation evidence as uncertain', async (status) => {
+        const ibkrBody = { error: 'Confirmation failed', detail: { warning: 'raw evidence' } };
+        mockFetch.mockResolvedValueOnce(mockResponse(ibkrBody, status));
+
+        const error = await client.confirmOrder('reply-http', ['o123']).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(OrderConfirmationError);
+        expect(error).toMatchObject({
+          status,
+          ibkrBody,
+          submissionUncertain: true,
+        });
+        expect(Object.keys(error)).not.toContain('ibkrBody');
+      });
+
+      it('preserves transport failure code as uncertain', async () => {
+        mockFetch.mockRejectedValueOnce(Object.assign(new Error('socket reset'), { code: 'ECONNRESET' }));
+
+        const error = await client.confirmOrder('reply-transport', []).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(OrderConfirmationError);
+        expect(error).toMatchObject({ transportCode: 'ECONNRESET', submissionUncertain: true });
       });
     });
   });

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -702,6 +702,32 @@ describe('IBClient', () => {
 
         expect(error).toMatchObject({ status: 400, submissionUncertain: true });
       });
+
+      it.each([400, 409])('should treat misleading HTTP %s proxy JSON as submission uncertain', async (status) => {
+        const proxyBody = status === 400
+          ? { code: 'BAD_GATEWAY', message: 'Cannot parse invalid upstream response' }
+          : { errorCode: 'BAD_GATEWAY', message: 'Cannot parse invalid upstream response' };
+        mockFetch
+          .mockResolvedValueOnce(mockResponse({
+            conid: 265598,
+            symbol: 'AAPL',
+            secType: 'STK',
+            currency: 'USD',
+          }))
+          .mockResolvedValueOnce(mockResponse(proxyBody, status));
+
+        const error = await client.placeOrder({
+          clientOrderId: `codex-proxy-${status}`,
+          accountId: 'U12345',
+          conid: 265598,
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 10,
+        }).catch((caught) => caught);
+
+        expect(error).toMatchObject({ status, ibkrBody: proxyBody, submissionUncertain: true });
+      });
     });
 
     describe('getOrders', () => {

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -1,6 +1,6 @@
 // test/ib-client.test.ts
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { IBClient, OrderSubmissionError, SymbolNotFoundError } from '../src/ib-client.js';
+import { IBClient, OrderCancellationError, OrderSubmissionError, SymbolNotFoundError } from '../src/ib-client.js';
 
 const { mockSpawn, mockFs } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
@@ -827,6 +827,67 @@ describe('IBClient', () => {
           expect.objectContaining({ method: 'GET' })
         );
         expect(result).toEqual(mockOrders);
+      });
+    });
+
+    describe('cancelOrder', () => {
+      it('should send DELETE to the exact account-scoped order path and preserve the broker response', async () => {
+        const brokerResponse = { orderId: '123', status: 'Cancelled', message: ['Order cancelled'] };
+        mockFetch.mockResolvedValueOnce(mockResponse(brokerResponse));
+
+        const result = await client.cancelOrder('U12345', '123');
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://localhost:5000/v1/api/iserver/account/U12345/order/123',
+          expect.objectContaining({ method: 'DELETE' }),
+        );
+        expect(result).toEqual(brokerResponse);
+      });
+
+      it('should preserve structured broker rejection status and body', async () => {
+        const ibkrBody = { error: 'Order cannot be cancelled', errorCode: 10147 };
+        mockFetch.mockResolvedValueOnce(mockResponse(ibkrBody, 400));
+
+        const error = await client.cancelOrder('U12345', '123').catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(OrderCancellationError);
+        expect(error).toMatchObject({ status: 400, ibkrBody });
+      });
+
+      it('should preserve a non-authentication HTTP 500 status and broker body', async () => {
+        const ibkrBody = { error: 'Cancellation backend failed', traceId: 'ibkr-500' };
+        mockFetch.mockResolvedValueOnce(mockResponse(ibkrBody, 500));
+
+        const error = await client.cancelOrder('U12345', '123').catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(OrderCancellationError);
+        expect(error).toMatchObject({ status: 500, ibkrBody });
+      });
+
+      it('should preserve authentication failures instead of replacing them with a generic cancellation error', async () => {
+        const authBody = { error: 'not authenticated' };
+        mockFetch.mockResolvedValueOnce(mockResponse(authBody, 401));
+
+        const error = await client.cancelOrder('U12345', '123').catch((caught) => caught);
+
+        expect(error).not.toBeInstanceOf(OrderCancellationError);
+        expect(error).toMatchObject({
+          name: 'HttpError',
+          response: { status: 401, data: authBody },
+        });
+      });
+
+      it('should preserve IBKR authentication failures carried in HTTP 500 responses', async () => {
+        const authBody = { error: { message: 'authentication required' } };
+        mockFetch.mockResolvedValueOnce(mockResponse(authBody, 500));
+
+        const error = await client.cancelOrder('U12345', '123').catch((caught) => caught);
+
+        expect(error).not.toBeInstanceOf(OrderCancellationError);
+        expect(error).toMatchObject({
+          name: 'HttpError',
+          response: { status: 500, data: authBody },
+        });
       });
     });
 

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -322,17 +322,19 @@ describe('IBClient', () => {
     });
 
     describe('placeOrder', () => {
-      it('should place market order successfully', async () => {
+      it('should place limit order successfully', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123', status: 'Submitted' }]));
 
         const orderRequest = {
+          clientOrderId: 'codex-20260716-basic',
           accountId: 'U12345',
           symbol: 'AAPL',
           action: 'BUY' as const,
-          orderType: 'MKT' as const,
+          orderType: 'LMT' as const,
           quantity: 10,
+          price: 150.50,
         };
 
         const result = await client.placeOrder(orderRequest);
@@ -340,7 +342,7 @@ describe('IBClient', () => {
         const body = findCallBody('/iserver/account/U12345/orders');
         expect(body.orders[0]).toEqual(expect.objectContaining({
           conid: 265598,
-          orderType: 'MKT',
+          orderType: 'LMT',
           side: 'BUY',
           quantity: 10,
         }));
@@ -353,6 +355,7 @@ describe('IBClient', () => {
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
+          clientOrderId: 'codex-20260716-price',
           accountId: 'U12345',
           symbol: 'AAPL',
           action: 'BUY' as const,
@@ -373,11 +376,13 @@ describe('IBClient', () => {
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
+          clientOrderId: 'codex-20260716-day',
           accountId: 'U12345',
           symbol: 'AAPL',
           action: 'BUY',
-          orderType: 'MKT',
+          orderType: 'LMT',
           quantity: 10,
+          price: 150.50,
         });
 
         const body = findCallBody('/iserver/account/U12345/orders');
@@ -390,11 +395,13 @@ describe('IBClient', () => {
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
+          clientOrderId: 'codex-20260716-gtc',
           accountId: 'U12345',
           symbol: 'AAPL',
           action: 'BUY',
-          orderType: 'MKT',
+          orderType: 'LMT',
           quantity: 10,
+          price: 150.50,
           tif: 'GTC',
         });
 
@@ -408,11 +415,13 @@ describe('IBClient', () => {
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
+          clientOrderId: 'codex-20260716-search-exchange',
           accountId: 'U12345',
           symbol: 'AAPL',
           action: 'BUY',
-          orderType: 'MKT',
+          orderType: 'LMT',
           quantity: 10,
+          price: 150.50,
           exchange: 'NASDAQ',
         });
 
@@ -428,11 +437,13 @@ describe('IBClient', () => {
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
+          clientOrderId: 'codex-20260716-payload-exchange',
           accountId: 'U12345',
           symbol: 'AAPL',
           action: 'BUY',
-          orderType: 'MKT',
+          orderType: 'LMT',
           quantity: 10,
+          price: 150.50,
           exchange: 'NASDAQ',
         });
 
@@ -445,32 +456,35 @@ describe('IBClient', () => {
 
         await expect(
           client.placeOrder({
+            clientOrderId: 'codex-20260716-invalid-symbol',
             accountId: 'U12345',
             symbol: 'INVALID',
             action: 'BUY',
-            orderType: 'MKT',
+            orderType: 'LMT',
             quantity: 10,
+            price: 150.50,
           })
         ).rejects.toThrow('Symbol INVALID not found');
       });
 
-      it('should include stopPrice for stop orders', async () => {
+      it('should include the client order ID for limit orders', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
+          clientOrderId: 'codex-20260716-001',
           accountId: 'U12345',
           symbol: 'AAPL',
-          action: 'SELL' as const,
-          orderType: 'STP' as const,
+          action: 'BUY' as const,
+          orderType: 'LMT' as const,
           quantity: 10,
-          stopPrice: 140.00,
+          price: 150.50,
         });
 
         const body = findCallBody('/iserver/account/U12345/orders');
         expect(body.orders[0]).toEqual(expect.objectContaining({
-          auxPrice: 140.00,
+          cOID: 'codex-20260716-001',
         }));
       });
     });
@@ -848,59 +862,4 @@ describe('Option contract support', () => {
     );
   });
 
-  it('should place option orders after resolving the option contract', async () => {
-    mockFetch
-      .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
-      .mockResolvedValueOnce(mockResponse([{ conid: 912345678, symbol: 'AAPL', secType: 'OPT' }]))
-      .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
-
-    await optionClient.placeOrder({
-      accountId: 'U12345',
-      symbol: 'AAPL',
-      secType: 'OPT',
-      expiry: 'JAN27',
-      strike: 200,
-      right: 'C',
-      action: 'BUY',
-      orderType: 'LMT',
-      quantity: 2,
-      price: 4.5,
-    });
-
-    const body = findCallBody('/iserver/account/U12345/orders');
-    expect(body.orders[0]).toEqual(
-      expect.objectContaining({
-        conid: 912345678,
-        secType: 'OPT',
-        side: 'BUY',
-        orderType: 'LMT',
-        quantity: 2,
-        price: 4.5,
-      }),
-    );
-  });
-
-  it('should place option orders with a pre-resolved conid', async () => {
-    mockFetch.mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
-
-    await optionClient.placeOrder({
-      accountId: 'U12345',
-      conid: 912345678,
-      secType: 'OPT',
-      action: 'SELL',
-      orderType: 'MKT',
-      quantity: 1,
-    });
-
-    const body = findCallBody('/iserver/account/U12345/orders');
-    expect(body.orders[0]).toEqual(
-      expect.objectContaining({
-        conid: 912345678,
-        secType: 'OPT',
-        side: 'SELL',
-        orderType: 'MKT',
-        quantity: 1,
-      }),
-    );
-  });
 });

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -654,6 +654,54 @@ describe('IBClient', () => {
           submissionUncertain: false,
         });
       });
+
+      it.each([502, 503, 504])('should treat HTTP %s gateway responses as submission uncertain', async (status) => {
+        const gatewayBody = { error: 'Order rejected', errorCode: 201, proxy: 'upstream' };
+        mockFetch
+          .mockResolvedValueOnce(mockResponse({
+            conid: 265598,
+            symbol: 'AAPL',
+            secType: 'STK',
+            currency: 'USD',
+          }))
+          .mockResolvedValueOnce(mockResponse(gatewayBody, status));
+
+        const error = await client.placeOrder({
+          clientOrderId: `codex-gateway-${status}`,
+          accountId: 'U12345',
+          conid: 265598,
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 10,
+        }).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(OrderSubmissionError);
+        expect(error).toMatchObject({ status, ibkrBody: gatewayBody, submissionUncertain: true });
+      });
+
+      it('should treat a malformed 4xx response as submission uncertain', async () => {
+        mockFetch
+          .mockResolvedValueOnce(mockResponse({
+            conid: 265598,
+            symbol: 'AAPL',
+            secType: 'STK',
+            currency: 'USD',
+          }))
+          .mockResolvedValueOnce(mockResponse('<html>proxy error</html>', 400));
+
+        const error = await client.placeOrder({
+          clientOrderId: 'codex-malformed-400',
+          accountId: 'U12345',
+          conid: 265598,
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 10,
+        }).catch((caught) => caught);
+
+        expect(error).toMatchObject({ status: 400, submissionUncertain: true });
+      });
     });
 
     describe('getOrders', () => {

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -651,7 +651,7 @@ describe('IBClient', () => {
         expect(error).toMatchObject({
           status: 400,
           ibkrBody,
-          submissionUncertain: false,
+          submissionUncertain: true,
         });
       });
 
@@ -718,6 +718,35 @@ describe('IBClient', () => {
 
         const error = await client.placeOrder({
           clientOrderId: `codex-proxy-${status}`,
+          accountId: 'U12345',
+          conid: 265598,
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 10,
+        }).catch((caught) => caught);
+
+        expect(error).toMatchObject({ status, ibkrBody: proxyBody, submissionUncertain: true });
+      });
+
+      it.each([400, 409])('should never infer a definite rejection from misleading numeric HTTP %s JSON', async (status) => {
+        const proxyBody = {
+          errorCode: 502,
+          error: status === 400
+            ? 'Gateway rejected upstream response'
+            : 'Gateway timeout exceeded while reading rejected upstream response',
+        };
+        mockFetch
+          .mockResolvedValueOnce(mockResponse({
+            conid: 265598,
+            symbol: 'AAPL',
+            secType: 'STK',
+            currency: 'USD',
+          }))
+          .mockResolvedValueOnce(mockResponse(proxyBody, status));
+
+        const error = await client.placeOrder({
+          clientOrderId: `codex-numeric-proxy-${status}`,
           accountId: 'U12345',
           conid: 265598,
           action: 'BUY',

--- a/test/ib-client.test.ts
+++ b/test/ib-client.test.ts
@@ -1,6 +1,6 @@
 // test/ib-client.test.ts
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { IBClient, SymbolNotFoundError } from '../src/ib-client.js';
+import { IBClient, OrderSubmissionError, SymbolNotFoundError } from '../src/ib-client.js';
 
 const { mockSpawn, mockFs } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
@@ -326,7 +326,7 @@ describe('IBClient', () => {
       it('should place limit order successfully', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
-          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK', currency: 'USD' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123', status: 'Submitted' }]));
 
         const orderRequest = {
@@ -354,7 +354,7 @@ describe('IBClient', () => {
       it('should include price for limit orders', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
-          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK', currency: 'USD' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -376,7 +376,7 @@ describe('IBClient', () => {
       it('should default tif to DAY when not specified', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
-          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK', currency: 'USD' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -396,7 +396,7 @@ describe('IBClient', () => {
       it('should use the user-provided tif when given', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
-          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK', currency: 'USD' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -417,7 +417,7 @@ describe('IBClient', () => {
       it('should include exchange in secdef/search URL when provided', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
-          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK', currency: 'USD' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -440,7 +440,7 @@ describe('IBClient', () => {
       it('should include exchange in the order payload when specified', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
-          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK', currency: 'USD' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -477,7 +477,7 @@ describe('IBClient', () => {
       it('should include the client order ID for limit orders', async () => {
         mockFetch
           .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL', sections: [{ secType: 'STK' }] }]))
-          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'AAPL', secType: 'STK', currency: 'USD' }))
           .mockResolvedValueOnce(mockResponse([{ id: 'order-123' }]));
 
         await client.placeOrder({
@@ -522,8 +522,8 @@ describe('IBClient', () => {
             { conid: 265598, symbol: 'ABC', sections: [{ secType: 'STK' }] },
             { conid: 765432, symbol: 'ABC', sections: [{ secType: 'STK' }] },
           ]))
-          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'ABC', secType: 'STK' }))
-          .mockResolvedValueOnce(mockResponse({ conid: 765432, symbol: 'ABC', secType: 'STK' }));
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'ABC', secType: 'STK', currency: 'USD' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 765432, symbol: 'ABC', secType: 'STK', currency: 'USD' }));
 
         await expect(client.placeOrder({
           clientOrderId: 'codex-ambiguous-symbol',
@@ -544,8 +544,8 @@ describe('IBClient', () => {
             { conid: 265598, symbol: 'ABC', sections: [{ secType: 'STK' }] },
             { conid: 765432, symbol: 'ABC', sections: [{ secType: 'OPT' }] },
           ]))
-          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'ABC', secType: 'STK' }))
-          .mockResolvedValueOnce(mockResponse({ conid: 765432, symbol: 'ABC', secType: 'STK' }));
+          .mockResolvedValueOnce(mockResponse({ conid: 265598, symbol: 'ABC', secType: 'STK', currency: 'USD' }))
+          .mockResolvedValueOnce(mockResponse({ conid: 765432, symbol: 'ABC', secType: 'STK', currency: 'USD' }));
 
         await expect(client.placeOrder({
           clientOrderId: 'codex-authoritative-ambiguity',
@@ -580,6 +580,79 @@ describe('IBClient', () => {
         })).rejects.toThrow(/stock|STK/i);
 
         expect(findCall('/iserver/account/U12345/orders')).toBeUndefined();
+      });
+
+      it('should reject a symbol with zero eligible USD stock contracts', async () => {
+        mockFetch
+          .mockResolvedValueOnce(mockResponse([{ conid: 265598, symbol: 'AAPL' }]))
+          .mockResolvedValueOnce(mockResponse({
+            conid: 265598,
+            symbol: 'AAPL',
+            secType: 'STK',
+            currency: 'EUR',
+          }));
+
+        await expect(client.placeOrder({
+          clientOrderId: 'codex-eur-symbol',
+          accountId: 'U12345',
+          symbol: 'AAPL',
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 10,
+        })).rejects.toThrow(/USD|eligible/i);
+
+        expect(findCall('/iserver/account/U12345/orders')).toBeUndefined();
+      });
+
+      it('should reject an explicit conid unless authoritative metadata is STK and USD', async () => {
+        mockFetch.mockResolvedValueOnce(mockResponse({
+          conid: 265598,
+          symbol: 'AAPL',
+          secType: 'STK',
+          currency: 'CAD',
+        }));
+
+        await expect(client.placeOrder({
+          clientOrderId: 'codex-cad-conid',
+          accountId: 'U12345',
+          conid: 265598,
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 10,
+        })).rejects.toThrow(/USD/i);
+
+        expect(findCall('/iserver/account/U12345/orders')).toBeUndefined();
+      });
+
+      it('should preserve status and the raw IBKR response body on submission errors', async () => {
+        const ibkrBody = { error: 'Order rejected', errorCode: 201, detail: { field: 'price' } };
+        mockFetch
+          .mockResolvedValueOnce(mockResponse({
+            conid: 265598,
+            symbol: 'AAPL',
+            secType: 'STK',
+            currency: 'USD',
+          }))
+          .mockResolvedValueOnce(mockResponse(ibkrBody, 400));
+
+        const error = await client.placeOrder({
+          clientOrderId: 'codex-rejected-conid',
+          accountId: 'U12345',
+          conid: 265598,
+          action: 'BUY',
+          orderType: 'LMT',
+          quantity: 1,
+          price: 10,
+        }).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(OrderSubmissionError);
+        expect(error).toMatchObject({
+          status: 400,
+          ibkrBody,
+          submissionUncertain: false,
+        });
       });
     });
 

--- a/test/logger-security.test.ts
+++ b/test/logger-security.test.ts
@@ -67,4 +67,35 @@ describe("Logger order-error security", () => {
     expect(contents).not.toContain("DO_NOT_LOG");
     expect(contents).not.toContain("DO_NOT_LOG_SUCCESS");
   });
+
+  it("redacts confirmation request, success, and error bodies", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ib-mcp-confirm-logger-"));
+    dirs.push(root);
+    const script = [
+      "const { IBClient } = await import('./src/ib-client.ts');",
+      "let request = 0;",
+      "globalThis.fetch = async () => request++ === 0",
+      "  ? new Response(JSON.stringify({ error: 'CONFIRM_ERROR_BODY_SECRET' }), { status: 400 })",
+      "  : new Response(JSON.stringify({ confirmed: true, secret: 'CONFIRM_SUCCESS_BODY_SECRET' }));",
+      "const client = new IBClient({ host: 'localhost', port: 5000 });",
+      "client.isAuthenticated = true;",
+      "await client.confirmOrder('reply-error', ['MESSAGE_ID_BODY_SECRET']).catch(() => undefined);",
+      "await client.confirmOrder('reply-success', ['MESSAGE_ID_SUCCESS_SECRET']);",
+      "client.destroy();",
+    ].join("\n");
+    const child = spawn(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
+      cwd: process.cwd(),
+      env: { ...process.env, IB_MCP_LOG_DIR: root, IB_MCP_CONSOLE_LOGGING: "false" },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    expect(await new Promise<number | null>((resolve) => child.once("exit", resolve))).toBe(0);
+    const contents = await readFile(path.join(root, "ib-mcp.log"), "utf8");
+    expect(contents).toContain('"status":400');
+    for (const secret of [
+      "CONFIRM_ERROR_BODY_SECRET",
+      "CONFIRM_SUCCESS_BODY_SECRET",
+      "MESSAGE_ID_BODY_SECRET",
+      "MESSAGE_ID_SUCCESS_SECRET",
+    ]) expect(contents).not.toContain(secret);
+  });
 });

--- a/test/logger-security.test.ts
+++ b/test/logger-security.test.ts
@@ -79,8 +79,8 @@ describe("Logger order-error security", () => {
       "  : new Response(JSON.stringify({ confirmed: true, secret: 'CONFIRM_SUCCESS_BODY_SECRET' }));",
       "const client = new IBClient({ host: 'localhost', port: 5000 });",
       "client.isAuthenticated = true;",
-      "await client.confirmOrder('reply-error', ['MESSAGE_ID_BODY_SECRET']).catch(() => undefined);",
-      "await client.confirmOrder('reply-success', ['MESSAGE_ID_SUCCESS_SECRET']);",
+      "await client.confirmOrder('RAW_REPLY_ERROR_CAPABILITY', ['MESSAGE_ID_BODY_SECRET']).catch(() => undefined);",
+      "await client.confirmOrder('RAW_REPLY_SUCCESS_CAPABILITY', ['MESSAGE_ID_SUCCESS_SECRET']);",
       "client.destroy();",
     ].join("\n");
     const child = spawn(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
@@ -96,6 +96,9 @@ describe("Logger order-error security", () => {
       "CONFIRM_SUCCESS_BODY_SECRET",
       "MESSAGE_ID_BODY_SECRET",
       "MESSAGE_ID_SUCCESS_SECRET",
+      "RAW_REPLY_ERROR_CAPABILITY",
+      "RAW_REPLY_SUCCESS_CAPABILITY",
     ]) expect(contents).not.toContain(secret);
+    expect(contents).toContain("/iserver/reply/[REDACTED]");
   });
 });

--- a/test/logger-security.test.ts
+++ b/test/logger-security.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const dirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("Logger order-error security", () => {
+  it("uses private modes and does not log the raw IBKR body", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ib-mcp-logger-"));
+    dirs.push(root);
+    const logDir = path.join(root, "logs");
+    const script = [
+      "const { IBClient } = await import('./src/ib-client.ts');",
+      "let request = 0;",
+      "globalThis.fetch = async () => {",
+      "  if (request++ % 2 === 0) return new Response(JSON.stringify({ conid: 265598, symbol: 'AAPL', secType: 'STK', currency: 'USD' }));",
+      "  if (request === 2) return new Response(JSON.stringify({ error: 'Order rejected', errorCode: 201, secret: 'DO_NOT_LOG' }), { status: 400 });",
+      "  return new Response(JSON.stringify([{ id: 'order-123', secret: 'DO_NOT_LOG_SUCCESS' }]));",
+      "};",
+      "const client = new IBClient({ host: 'localhost', port: 5000 });",
+      "client.isAuthenticated = true;",
+      "await client.placeOrder({ clientOrderId: 'log-security', accountId: 'U12345', conid: 265598, action: 'BUY', orderType: 'LMT', quantity: 1, price: 10 }).catch(() => undefined);",
+      "await client.placeOrder({ clientOrderId: 'log-security-success', accountId: 'U12345', conid: 265598, action: 'BUY', orderType: 'LMT', quantity: 1, price: 10 });",
+      "client.destroy();",
+    ].join("\n");
+    const child = spawn(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
+      cwd: process.cwd(),
+      env: { ...process.env, IB_MCP_LOG_DIR: logDir, IB_MCP_CONSOLE_LOGGING: "false" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stderr: Buffer[] = [];
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    const exitCode = await new Promise<number | null>((resolve) => child.once("exit", resolve));
+    expect(Buffer.concat(stderr).toString()).toBe("");
+    expect(exitCode).toBe(0);
+
+    const logFile = path.join(logDir, "ib-mcp.log");
+    expect((await stat(logDir)).mode & 0o777).toBe(0o700);
+    expect((await stat(logFile)).mode & 0o777).toBe(0o600);
+    const contents = await readFile(logFile, "utf8");
+    expect(contents).toContain('"status":400');
+    expect(contents).not.toContain("DO_NOT_LOG");
+    expect(contents).not.toContain("DO_NOT_LOG_SUCCESS");
+  });
+});

--- a/test/logger-security.test.ts
+++ b/test/logger-security.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -11,6 +11,25 @@ afterEach(async () => {
 });
 
 describe("Logger order-error security", () => {
+  it("tightens an existing log before appending", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ib-mcp-logger-existing-"));
+    dirs.push(root);
+    const logDir = path.join(root, "logs");
+    const logFile = path.join(logDir, "ib-mcp.log");
+    await mkdir(logDir, { recursive: true });
+    await writeFile(logFile, "old\n", { mode: 0o644 });
+    await chmod(logFile, 0o644);
+    const script = "const { Logger } = await import('./src/logger.ts'); Logger.info('new-secret-free-line');";
+    const child = spawn(process.execPath, ["--import", "tsx", "--input-type=module", "-e", script], {
+      cwd: process.cwd(),
+      env: { ...process.env, IB_MCP_LOG_DIR: logDir },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    expect(await new Promise<number | null>((resolve) => child.once("exit", resolve))).toBe(0);
+    expect((await stat(logFile)).mode & 0o777).toBe(0o600);
+    expect(await readFile(logFile, "utf8")).toContain("new-secret-free-line");
+  });
+
   it("uses private modes and does not log the raw IBKR body", async () => {
     const root = await mkdtemp(path.join(tmpdir(), "ib-mcp-logger-"));
     dirs.push(root);

--- a/test/order-idempotency-store.test.ts
+++ b/test/order-idempotency-store.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, open, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -96,5 +97,105 @@ describe("OrderIdempotencyStore", () => {
     const serialized = await readFile(file, "utf8");
 
     expect(serialized).not.toMatch(/password|cookie|token|credential/i);
+  });
+
+  it("recovers when a real process dies after creating an empty lock", async () => {
+    const file = await makeStorePath();
+    const lockPath = `${file}.lock`;
+    const child = spawn(process.execPath, [
+      "-e",
+      "require('fs').openSync(process.argv[1], 'wx', 0o600); process.stdout.write('ready\\n'); setInterval(() => {}, 1000)",
+      lockPath,
+    ], { stdio: ["ignore", "pipe", "inherit"] });
+    await new Promise<void>((resolve, reject) => {
+      child.once("error", reject);
+      child.stdout!.once("data", () => resolve());
+    });
+    child.kill("SIGKILL");
+    await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+
+    const store = new OrderIdempotencyStore(file, { lockInitializationGraceMs: 25 });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const reservation = await store.reserve(request);
+
+    expect(reservation.owner).toBe(true);
+  });
+
+  it("fsyncs the parent directory after rename", async () => {
+    const file = await makeStorePath();
+    const events: string[] = [];
+    const store = new OrderIdempotencyStore(file, {
+      fileSystem: {
+        open: async (target, flags, mode) => {
+          const handle = await open(target, flags, mode);
+          if (target === path.dirname(file)) {
+            const originalSync = handle.sync.bind(handle);
+            handle.sync = async () => {
+              events.push("parent-sync");
+              return originalSync();
+            };
+          }
+          return handle;
+        },
+        rename: async (source, destination) => {
+          events.push("rename");
+          await (await import("node:fs/promises")).rename(source, destination);
+        },
+      },
+    });
+
+    await store.reserve(request);
+
+    expect(events).toEqual(["rename", "parent-sync"]);
+  });
+
+  it("removes temp files when temp fsync fails", async () => {
+    const file = await makeStorePath();
+    const store = new OrderIdempotencyStore(file, {
+      fileSystem: {
+        open: async (target, flags, mode) => {
+          const handle = await open(target, flags, mode);
+          if (target.endsWith(".tmp")) {
+            handle.sync = async () => { throw new Error("injected temp fsync failure"); };
+          }
+          return handle;
+        },
+      },
+    });
+
+    await expect(store.reserve(request)).rejects.toThrow("injected temp fsync failure");
+    expect((await readdir(path.dirname(file))).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+  });
+
+  it("removes its lock when lock metadata fsync fails", async () => {
+    const file = await makeStorePath();
+    const lockPath = `${file}.lock`;
+    const store = new OrderIdempotencyStore(file, {
+      fileSystem: {
+        open: async (target, flags, mode) => {
+          const handle = await open(target, flags, mode);
+          if (target === lockPath) {
+            handle.sync = async () => { throw new Error("injected lock fsync failure"); };
+          }
+          return handle;
+        },
+      },
+    });
+
+    await expect(store.reserve(request)).rejects.toThrow("injected lock fsync failure");
+    expect(await readdir(path.dirname(file))).not.toContain(path.basename(lockPath));
+  });
+
+  it("tightens existing store directory and data file permissions", async () => {
+    const file = await makeStorePath();
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, `${JSON.stringify({ version: 1, records: {} })}\n`, { mode: 0o644 });
+    await chmod(path.dirname(file), 0o755);
+    await chmod(file, 0o644);
+
+    await new OrderIdempotencyStore(file).reserve(request);
+
+    expect((await stat(path.dirname(file))).mode & 0o777).toBe(0o700);
+    expect((await stat(file)).mode & 0o777).toBe(0o600);
   });
 });

--- a/test/order-idempotency-store.test.ts
+++ b/test/order-idempotency-store.test.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  OrderIdempotencyConflictError,
+  OrderIdempotencyStore,
+} from "../src/order-idempotency-store.js";
+
+const dirs: string[] = [];
+
+async function makeStorePath(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "ib-mcp-orders-"));
+  dirs.push(dir);
+  return path.join(dir, "orders.json");
+}
+
+const request = {
+  clientOrderId: "codex-durable-001",
+  accountId: "U12345",
+  symbol: "AAPL",
+  action: "BUY" as const,
+  orderType: "LMT" as const,
+  quantity: 2,
+  price: 201.5,
+  tif: "DAY" as const,
+};
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("OrderIdempotencyStore", () => {
+  it("returns an identical completed record after restart", async () => {
+    const file = await makeStorePath();
+    const first = new OrderIdempotencyStore(file);
+    const reservation = await first.reserve(request);
+    expect(reservation.owner).toBe(true);
+    await first.recordResponse(request, [{ id: "order-123", status: "Submitted" }]);
+
+    const restarted = new OrderIdempotencyStore(file);
+    const replay = await restarted.reserve({ ...request, tif: undefined });
+
+    expect(replay).toMatchObject({
+      owner: false,
+      record: {
+        clientOrderId: request.clientOrderId,
+        state: "completed",
+        response: [{ id: "order-123", status: "Submitted" }],
+      },
+    });
+  });
+
+  it("rejects conflicting reuse of a client order ID", async () => {
+    const store = new OrderIdempotencyStore(await makeStorePath());
+    await store.reserve(request);
+
+    await expect(store.reserve({ ...request, quantity: 3 })).rejects.toBeInstanceOf(
+      OrderIdempotencyConflictError,
+    );
+  });
+
+  it("grants one owner across concurrent store instances", async () => {
+    const file = await makeStorePath();
+    const stores = Array.from({ length: 8 }, () => new OrderIdempotencyStore(file));
+
+    const reservations = await Promise.all(stores.map((store) => store.reserve(request)));
+
+    expect(reservations.filter((entry) => entry.owner)).toHaveLength(1);
+  });
+
+  it("keeps uncertain submissions non-retryable after restart", async () => {
+    const file = await makeStorePath();
+    const store = new OrderIdempotencyStore(file);
+    await store.reserve(request);
+    await store.recordUncertain(request, {
+      message: "request timed out",
+      transportCode: "UND_ERR_CONNECT_TIMEOUT",
+      submissionUncertain: true,
+    });
+
+    const restarted = new OrderIdempotencyStore(file);
+    const reservation = await restarted.reserve(request);
+
+    expect(reservation.owner).toBe(false);
+    expect(reservation.record).toMatchObject({
+      state: "uncertain",
+      error: { submissionUncertain: true, transportCode: "UND_ERR_CONNECT_TIMEOUT" },
+    });
+  });
+
+  it("persists only order data and never credentials", async () => {
+    const file = await makeStorePath();
+    const store = new OrderIdempotencyStore(file);
+    await store.reserve(request);
+    const serialized = await readFile(file, "utf8");
+
+    expect(serialized).not.toMatch(/password|cookie|token|credential/i);
+  });
+});

--- a/test/order-idempotency-store.test.ts
+++ b/test/order-idempotency-store.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, open, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, link, mkdir, mkdtemp, open, readFile, readdir, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -68,6 +68,40 @@ describe("OrderIdempotencyStore", () => {
     const reservations = await Promise.all(stores.map((store) => store.reserve(request)));
 
     expect(reservations.filter((entry) => entry.owner)).toHaveLength(1);
+  });
+
+  it("publishes only complete owner metadata and never grants two owners when one initializer is paused", async () => {
+    const file = await makeStorePath();
+    let releaseFirstLink!: () => void;
+    const firstLinkPaused = new Promise<void>((resolve) => { releaseFirstLink = resolve; });
+    let firstReachedLink!: () => void;
+    const firstAtLink = new Promise<void>((resolve) => { firstReachedLink = resolve; });
+    let pause = true;
+    const slow = new OrderIdempotencyStore(file, {
+      lockInitializationGraceMs: 0,
+      fileSystem: {
+        link: async (source, destination) => {
+          if (pause) {
+            pause = false;
+            firstReachedLink();
+            await firstLinkPaused;
+          }
+          await link(source, destination);
+        },
+      },
+    });
+    const competitor = new OrderIdempotencyStore(file, { lockInitializationGraceMs: 0 });
+
+    const slowReservation = slow.reserve(request);
+    await firstAtLink;
+    const competitorReservation = await competitor.reserve(request);
+    releaseFirstLink();
+    const delayedReservation = await slowReservation;
+
+    expect([competitorReservation, delayedReservation].filter((entry) => entry.owner)).toHaveLength(1);
+    expect(competitorReservation.owner).toBe(true);
+    expect(delayedReservation.owner).toBe(false);
+    await expect(readFile(`${file}.lock`, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("keeps uncertain submissions non-retryable after restart", async () => {
@@ -174,7 +208,7 @@ describe("OrderIdempotencyStore", () => {
       fileSystem: {
         open: async (target, flags, mode) => {
           const handle = await open(target, flags, mode);
-          if (target === lockPath) {
+          if (String(target).startsWith(`${lockPath}.`) && String(target).endsWith(".owner")) {
             handle.sync = async () => { throw new Error("injected lock fsync failure"); };
           }
           return handle;
@@ -183,7 +217,46 @@ describe("OrderIdempotencyStore", () => {
     });
 
     await expect(store.reserve(request)).rejects.toThrow("injected lock fsync failure");
-    expect(await readdir(path.dirname(file))).not.toContain(path.basename(lockPath));
+    expect((await readdir(path.dirname(file))).filter((name) => name.includes(".lock"))).toEqual([]);
+  });
+
+  it("cleans an unpublished owner file and preserves the write error when close also fails", async () => {
+    const file = await makeStorePath();
+    const store = new OrderIdempotencyStore(file, {
+      fileSystem: {
+        open: async (target, flags, mode) => {
+          const handle = await open(target, flags, mode);
+          if (String(target).includes(".lock.") && String(target).endsWith(".owner")) {
+            handle.writeFile = async () => { throw new Error("primary owner write failure"); };
+            handle.close = async () => { throw new Error("secondary owner close failure"); };
+          }
+          return handle;
+        },
+      },
+    });
+
+    await expect(store.reserve(request)).rejects.toThrow("primary owner write failure");
+    expect((await readdir(path.dirname(file))).filter((name) => name.endsWith(".owner"))).toEqual([]);
+  });
+
+  it("cleans a temp file and preserves the write error when close also fails", async () => {
+    const file = await makeStorePath();
+    const store = new OrderIdempotencyStore(file, {
+      fileSystem: {
+        open: async (target, flags, mode) => {
+          const handle = await open(target, flags, mode);
+          if (String(target).endsWith(".tmp")) {
+            handle.writeFile = async () => { throw new Error("primary temp write failure"); };
+            handle.close = async () => { throw new Error("secondary temp close failure"); };
+          }
+          return handle;
+        },
+        unlink,
+      },
+    });
+
+    await expect(store.reserve(request)).rejects.toThrow("primary temp write failure");
+    expect((await readdir(path.dirname(file))).filter((name) => name.endsWith(".tmp"))).toEqual([]);
   });
 
   it("tightens existing store directory and data file permissions", async () => {

--- a/test/order-idempotency-store.test.ts
+++ b/test/order-idempotency-store.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  OrderConfirmationAuthorizationError,
   OrderIdempotencyConflictError,
   OrderIdempotencyStore,
 } from "../src/order-idempotency-store.js";
@@ -46,10 +47,108 @@ describe("OrderIdempotencyStore", () => {
       owner: false,
       record: {
         clientOrderId: request.clientOrderId,
+        accountId: "U12345",
         state: "completed",
         response: [{ id: "order-123", status: "Submitted" }],
       },
     });
+  });
+
+  it("authorizes exactly one allowlisted broker reply and persists a multi-step chain", async () => {
+    const file = await makeStorePath();
+    const first = new OrderIdempotencyStore(file);
+    await first.reserve(request);
+    await first.recordResponse(request, [{ id: "reply-1", message: ["warning"] }]);
+
+    const restarted = new OrderIdempotencyStore(file);
+    const firstStep = await restarted.reserveConfirmation("U12345", "reply-1");
+    expect(firstStep).toMatchObject({ owner: true, record: { accountId: "U12345" } });
+    await restarted.recordConfirmationResponse(
+      request.clientOrderId,
+      "reply-1",
+      [{ id: "reply-2", message: ["second warning"] }],
+    );
+
+    const secondRestart = new OrderIdempotencyStore(file);
+    expect(await secondRestart.reserveConfirmation("U12345", "reply-2"))
+      .toMatchObject({ owner: true });
+    const persisted = await secondRestart.get(request.clientOrderId);
+    expect(persisted?.confirmations).toMatchObject([
+      { replyId: "reply-1", state: "completed", replyIds: ["reply-2"], response: [{ id: "reply-2" }] },
+      { replyId: "reply-2", state: "reserved" },
+    ]);
+  });
+
+  it("rejects a reply id duplicated across allowed and foreign account records", async () => {
+    const store = new OrderIdempotencyStore(await makeStorePath());
+    await store.reserve(request);
+    await store.recordResponse(request, [{ id: "cross-account-duplicate", message: ["warning"] }]);
+    const foreign = { ...request, clientOrderId: "foreign-order", accountId: "U99999" };
+    await store.reserve(foreign);
+    await store.recordResponse(foreign, [{ id: "cross-account-duplicate", messageIds: ["o123"] }]);
+
+    await expect(store.reserveConfirmation("U12345", "cross-account-duplicate"))
+      .rejects.toBeInstanceOf(OrderConfirmationAuthorizationError);
+  });
+
+  it("fails closed for unknown, foreign-account, legacy, and ambiguous reply ids", async () => {
+    const file = await makeStorePath();
+    const store = new OrderIdempotencyStore(file);
+    await store.reserve(request);
+    await store.recordResponse(request, [
+      { id: "reply-1", message: ["warning"] },
+      { id: "duplicate", message: ["warning"] },
+      { id: "duplicate", messageIds: ["o123"] },
+    ]);
+
+    await expect(store.reserveConfirmation("U12345", "missing"))
+      .rejects.toBeInstanceOf(OrderConfirmationAuthorizationError);
+    await expect(store.reserveConfirmation("U99999", "reply-1"))
+      .rejects.toBeInstanceOf(OrderConfirmationAuthorizationError);
+    await expect(store.reserveConfirmation("U12345", "duplicate"))
+      .rejects.toBeInstanceOf(OrderConfirmationAuthorizationError);
+
+    const document = JSON.parse(await readFile(file, "utf8"));
+    delete document.records[request.clientOrderId].accountId;
+    await writeFile(file, `${JSON.stringify(document)}\n`);
+    await expect(new OrderIdempotencyStore(file).reserveConfirmation("U12345", "reply-1"))
+      .rejects.toBeInstanceOf(OrderConfirmationAuthorizationError);
+  });
+
+  it("does not authorize fuzzy or arbitrary nested id fields", async () => {
+    const store = new OrderIdempotencyStore(await makeStorePath());
+    await store.reserve(request);
+    await store.recordResponse(request, {
+      message: "reply-fuzzy",
+      details: { id: "nested-untrusted" },
+      response: [{ id: "nested-wrapper-untrusted" }],
+    });
+
+    for (const replyId of ["reply-fuzzy", "nested-untrusted", "nested-wrapper-untrusted"]) {
+      await expect(store.reserveConfirmation("U12345", replyId))
+        .rejects.toBeInstanceOf(OrderConfirmationAuthorizationError);
+    }
+  });
+
+  it("does not mistake an ordinary successful order id for a warning reply id", async () => {
+    const store = new OrderIdempotencyStore(await makeStorePath());
+    await store.reserve(request);
+    await store.recordResponse(request, [{ id: "broker-order-id", status: "Submitted" }]);
+
+    await expect(store.reserveConfirmation("U12345", "broker-order-id"))
+      .rejects.toBeInstanceOf(OrderConfirmationAuthorizationError);
+  });
+
+  it("authorizes an exact warning id preserved in uncertain brokerResponse evidence", async () => {
+    const store = new OrderIdempotencyStore(await makeStorePath());
+    await store.reserve(request);
+    await store.recordUncertain(request, {
+      code: "SUBMISSION_UNCERTAIN",
+      brokerResponse: [{ id: "uncertain-reply", messageIds: ["o123"] }],
+    });
+
+    expect(await store.reserveConfirmation("U12345", "uncertain-reply"))
+      .toMatchObject({ owner: true });
   });
 
   it("rejects conflicting reuse of a client order ID", async () => {
@@ -153,6 +252,21 @@ describe("OrderIdempotencyStore", () => {
     const reservation = await store.reserve(request);
 
     expect(reservation.owner).toBe(true);
+  });
+
+  it("recovers a stale lock when a live PID has a different process-start identity", async () => {
+    const file = await makeStorePath();
+    await writeFile(`${file}.lock`, JSON.stringify({
+      pid: process.pid,
+      token: "stale-owner",
+      identity: "old-process-start",
+    }), { mode: 0o600 });
+    const store = new OrderIdempotencyStore(file, {
+      lockInitializationGraceMs: 0,
+      processIdentity: () => "current-process-start",
+    });
+
+    expect((await store.reserve(request)).owner).toBe(true);
   });
 
   it("fsyncs the parent directory after rename", async () => {

--- a/test/order-idempotency-store.test.ts
+++ b/test/order-idempotency-store.test.ts
@@ -239,6 +239,28 @@ describe("OrderIdempotencyStore", () => {
     expect((await readdir(path.dirname(file))).filter((name) => name.endsWith(".owner"))).toEqual([]);
   });
 
+  it("cleans the published owner alias during release when the first unlink fails", async () => {
+    const file = await makeStorePath();
+    let failedPublishedOwnerCleanup = false;
+    const store = new OrderIdempotencyStore(file, {
+      fileSystem: {
+        unlink: async (target) => {
+          if (!failedPublishedOwnerCleanup && String(target).endsWith(".owner")) {
+            failedPublishedOwnerCleanup = true;
+            throw Object.assign(new Error("injected first owner unlink failure"), { code: "EIO" });
+          }
+          await unlink(target);
+        },
+      },
+    });
+
+    expect((await store.reserve(request)).owner).toBe(true);
+
+    expect(failedPublishedOwnerCleanup).toBe(true);
+    expect((await readdir(path.dirname(file))).filter((name) => name.endsWith(".owner"))).toEqual([]);
+    expect((await readdir(path.dirname(file))).filter((name) => name.endsWith(".lock"))).toEqual([]);
+  });
+
   it("cleans a temp file and preserves the write error when close also fails", async () => {
     const file = await makeStorePath();
     const store = new OrderIdempotencyStore(file, {

--- a/test/order-policy.test.ts
+++ b/test/order-policy.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { OrderPolicy } from "../src/order-policy.js";
+
+const validOrder = {
+  clientOrderId: "codex-20260716-001",
+  accountId: "U12345",
+  symbol: "AAPL",
+  action: "BUY" as const,
+  orderType: "LMT" as const,
+  quantity: 2,
+  price: 185.5,
+};
+
+describe("OrderPolicy", () => {
+  it("treats omitted and non-false values as read-only", () => {
+    expect(() => new OrderPolicy({}).assertWriteEnabled()).toThrow(/read-only/i);
+    expect(() => new OrderPolicy({ IB_READ_ONLY_MODE: "False" }).assertWriteEnabled()).toThrow(/read-only/i);
+    expect(() => new OrderPolicy({ IB_READ_ONLY_MODE: true }).assertWriteEnabled()).toThrow(/read-only/i);
+  });
+
+  it.each([false, "false"])("allows explicit %j only with an account allowlist", (value) => {
+    expect(() => new OrderPolicy({ IB_READ_ONLY_MODE: value }).assertWriteEnabled())
+      .toThrow(/IB_ALLOWED_ACCOUNT_ID/);
+    expect(() => new OrderPolicy({
+      IB_READ_ONLY_MODE: value,
+      IB_ALLOWED_ACCOUNT_ID: "U12345",
+    }).assertWriteEnabled()).not.toThrow();
+  });
+
+  it("rejects an account other than the allowlisted account", () => {
+    const policy = new OrderPolicy({ IB_READ_ONLY_MODE: false, IB_ALLOWED_ACCOUNT_ID: "U12345" });
+    expect(() => policy.assertAllowedAccount("U99999")).toThrow(/U12345/);
+  });
+
+  it("accepts a valid limit stock order", () => {
+    const policy = new OrderPolicy({ IB_READ_ONLY_MODE: false, IB_ALLOWED_ACCOUNT_ID: "U12345" });
+    expect(() => policy.validatePlaceOrder(validOrder)).not.toThrow();
+  });
+
+  it.each([
+    ["market order", { orderType: "MKT" }],
+    ["stop order", { orderType: "STP", stopPrice: 180 }],
+    ["option secType", { secType: "OPT" }],
+    ["option expiry", { expiry: "JAN27" }],
+    ["option strike", { strike: 200 }],
+    ["option right", { right: "C" }],
+    ["suppressed confirmations", { suppressConfirmations: true }],
+    ["missing price", { price: undefined }],
+    ["zero price", { price: 0 }],
+    ["nonfinite price", { price: Number.POSITIVE_INFINITY }],
+    ["zero quantity", { quantity: 0 }],
+    ["nonfinite quantity", { quantity: Number.NaN }],
+    ["blank client order id", { clientOrderId: "   " }],
+  ])("rejects %s", (_label, override) => {
+    const policy = new OrderPolicy({ IB_READ_ONLY_MODE: false, IB_ALLOWED_ACCOUNT_ID: "U12345" });
+    expect(() => policy.validatePlaceOrder({ ...validOrder, ...override })).toThrow();
+  });
+});

--- a/test/order-policy.test.ts
+++ b/test/order-policy.test.ts
@@ -37,6 +37,11 @@ describe("OrderPolicy", () => {
     expect(() => policy.validatePlaceOrder(validOrder)).not.toThrow();
   });
 
+  it("requires either symbol or conid", () => {
+    const policy = new OrderPolicy({ IB_READ_ONLY_MODE: false, IB_ALLOWED_ACCOUNT_ID: "U12345" });
+    expect(() => policy.validatePlaceOrder({ ...validOrder, symbol: undefined })).toThrow(/symbol or conid/i);
+  });
+
   it.each([
     ["market order", { orderType: "MKT" }],
     ["stop order", { orderType: "STP", stopPrice: 180 }],

--- a/test/read-only-mode.test.ts
+++ b/test/read-only-mode.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerTools } from "../src/tools.js";
 import { IBClient } from "../src/ib-client.js";
 import { IBGatewayManager } from "../src/gateway-manager.js";
@@ -25,6 +27,10 @@ describe("read-only safety defaults", () => {
     registeredTools = [];
     mockMcpServer = {
       tool: vi.fn().mockImplementation((name) => {
+        registeredTools.push(name);
+        return mockMcpServer;
+      }),
+      registerTool: vi.fn().mockImplementation((name) => {
         registeredTools.push(name);
         return mockMcpServer;
       }),
@@ -63,4 +69,49 @@ describe("read-only safety defaults", () => {
     });
     for (const tool of WRITE_TOOLS) expect(registeredTools).toContain(tool);
   });
+});
+
+describe("place_order MCP entrypoint validation", () => {
+  it.each(["secType", "expiry", "right", "suppressConfirmations"])(
+    "rejects forbidden field %s instead of stripping it",
+    async (field) => {
+      const server = new McpServer({ name: "test-server", version: "1.0.0" });
+      const ibClient = {
+        checkAuthenticationStatus: vi.fn().mockResolvedValue(true),
+        placeOrder: vi.fn().mockResolvedValue({ orderId: "unsafe" }),
+      } as unknown as IBClient;
+      registerTools(server, ibClient, undefined, {
+        IB_READ_ONLY_MODE: false,
+        IB_ALLOWED_ACCOUNT_ID: "U12345",
+      });
+
+      const client = new Client({ name: "test-client", version: "1.0.0" });
+      const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      try {
+        const result = await client.callTool({
+          name: "place_order",
+          arguments: {
+            clientOrderId: `forbidden-${field}`,
+            accountId: "U12345",
+            symbol: "AAPL",
+            action: "BUY",
+            orderType: "LMT",
+            quantity: 1,
+            price: 150,
+            [field]: field === "suppressConfirmations" ? true : "forbidden",
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(JSON.stringify(result.content)).toMatch(/unrecognized|invalid/i);
+        expect(ibClient.placeOrder).not.toHaveBeenCalled();
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    },
+  );
 });

--- a/test/read-only-mode.test.ts
+++ b/test/read-only-mode.test.ts
@@ -15,6 +15,7 @@ const WRITE_TOOLS = [
   "create_alert",
   "activate_alert",
   "delete_alert",
+  "cancel_order",
 ];
 
 describe("read-only safety defaults", () => {

--- a/test/read-only-mode.test.ts
+++ b/test/read-only-mode.test.ts
@@ -1,76 +1,66 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { registerTools } from '../src/tools.js';
-import { IBClient } from '../src/ib-client.js';
-import { IBGatewayManager } from '../src/gateway-manager.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTools } from "../src/tools.js";
+import { IBClient } from "../src/ib-client.js";
+import { IBGatewayManager } from "../src/gateway-manager.js";
 
-// Mock dependencies
-vi.mock('../src/ib-client.js');
-vi.mock('../src/gateway-manager.js');
+vi.mock("../src/ib-client.js");
+vi.mock("../src/gateway-manager.js");
 
-describe('Read-Only Mode Tool Registration', () => {
-    let mockMcpServer: McpServer;
-    let mockIBClient: IBClient;
-    let mockGatewayManager: IBGatewayManager;
-    let registeredTools: string[] = [];
+const WRITE_TOOLS = [
+  "place_order",
+  "confirm_order",
+  "create_alert",
+  "activate_alert",
+  "delete_alert",
+];
 
-    beforeEach(() => {
-        registeredTools = [];
-        mockMcpServer = {
-            tool: vi.fn().mockImplementation((name, ...args) => {
-                registeredTools.push(name);
-                return mockMcpServer;
-            }),
-        } as unknown as McpServer;
+describe("read-only safety defaults", () => {
+  let mockMcpServer: McpServer;
+  let mockIBClient: IBClient;
+  let mockGatewayManager: IBGatewayManager;
+  let registeredTools: string[];
 
-        mockIBClient = {} as IBClient;
-        mockGatewayManager = {} as IBGatewayManager;
+  beforeEach(() => {
+    registeredTools = [];
+    mockMcpServer = {
+      tool: vi.fn().mockImplementation((name) => {
+        registeredTools.push(name);
+        return mockMcpServer;
+      }),
+    } as unknown as McpServer;
+    mockIBClient = {} as IBClient;
+    mockGatewayManager = {} as IBGatewayManager;
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("defaults omitted IB_READ_ONLY_MODE to true", async () => {
+    vi.stubEnv("IB_READ_ONLY_MODE", "");
+    vi.resetModules();
+    const { config } = await import("../src/config.js");
+    expect(config.IB_READ_ONLY_MODE).toBe(true);
+  });
+
+  it("does not register write tools when read-only mode is omitted", () => {
+    registerTools(mockMcpServer, mockIBClient, mockGatewayManager);
+    expect(registeredTools).toEqual(expect.arrayContaining([
+      "get_positions", "get_market_data", "get_account_info", "get_live_orders",
+    ]));
+    for (const tool of WRITE_TOOLS) expect(registeredTools).not.toContain(tool);
+  });
+
+  it("refuses live write registration without an allowed account", () => {
+    expect(() => registerTools(mockMcpServer, mockIBClient, mockGatewayManager, {
+      IB_READ_ONLY_MODE: false,
+    })).toThrow(/IB_ALLOWED_ACCOUNT_ID/);
+  });
+
+  it("registers write tools only with explicit false and an allowed account", () => {
+    registerTools(mockMcpServer, mockIBClient, mockGatewayManager, {
+      IB_READ_ONLY_MODE: false,
+      IB_ALLOWED_ACCOUNT_ID: "U12345",
     });
-
-    it('should register ALL tools when read-only mode is DISABLED (default)', () => {
-        const config = {}; // No IB_READ_ONLY_MODE
-        registerTools(mockMcpServer, mockIBClient, mockGatewayManager, config);
-
-        // Verify write tools are registered
-        expect(registeredTools).toContain('place_order');
-        expect(registeredTools).toContain('confirm_order');
-        expect(registeredTools).toContain('create_alert');
-        expect(registeredTools).toContain('activate_alert');
-        expect(registeredTools).toContain('delete_alert');
-
-        // Verify read tools are also registered
-        expect(registeredTools).toContain('get_positions');
-        expect(registeredTools).toContain('get_market_data');
-    });
-
-    it('should register ALL tools when read-only mode is EXPLICITLY FALSE', () => {
-        const config = { IB_READ_ONLY_MODE: false };
-        registerTools(mockMcpServer, mockIBClient, mockGatewayManager, config);
-
-        expect(registeredTools).toContain('place_order');
-        expect(registeredTools).toContain('confirm_order');
-        expect(registeredTools).toContain('create_alert');
-        expect(registeredTools).toContain('activate_alert');
-        expect(registeredTools).toContain('delete_alert');
-    });
-
-    it('should NOT register modification tools when read-only mode is ENABLED', () => {
-        const config = { IB_READ_ONLY_MODE: true };
-        registerTools(mockMcpServer, mockIBClient, mockGatewayManager, config);
-
-        // Verify write tools are NOT registered
-        expect(registeredTools).not.toContain('place_order');
-        expect(registeredTools).not.toContain('confirm_order');
-        expect(registeredTools).not.toContain('create_alert');
-        expect(registeredTools).not.toContain('activate_alert');
-        expect(registeredTools).not.toContain('delete_alert');
-
-        // Verify read tools ARE registered
-        expect(registeredTools).toContain('get_positions');
-        expect(registeredTools).toContain('get_market_data');
-        expect(registeredTools).toContain('get_account_info');
-        expect(registeredTools).toContain('get_live_orders');
-        expect(registeredTools).toContain('get_order_status');
-        expect(registeredTools).toContain('get_alerts');
-    });
+    for (const tool of WRITE_TOOLS) expect(registeredTools).toContain(tool);
+  });
 });

--- a/test/read-only-mode.test.ts
+++ b/test/read-only-mode.test.ts
@@ -72,6 +72,51 @@ describe("read-only safety defaults", () => {
 });
 
 describe("place_order MCP entrypoint validation", () => {
+  it("publishes the complete object contract through tools/list", async () => {
+    const server = new McpServer({ name: "test-server", version: "1.0.0" });
+    const ibClient = {} as IBClient;
+    registerTools(server, ibClient, undefined, {
+      IB_READ_ONLY_MODE: false,
+      IB_ALLOWED_ACCOUNT_ID: "U12345",
+    });
+
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const { tools } = await client.listTools();
+      const placeOrder = tools.find((tool) => tool.name === "place_order");
+
+      expect(placeOrder?.inputSchema.type).toBe("object");
+      expect(Object.keys(placeOrder?.inputSchema.properties ?? {})).toEqual(expect.arrayContaining([
+        "clientOrderId",
+        "accountId",
+        "symbol",
+        "conid",
+        "action",
+        "orderType",
+        "quantity",
+        "price",
+        "exchange",
+        "tif",
+      ]));
+      expect(placeOrder?.inputSchema.required).toEqual(expect.arrayContaining([
+        "clientOrderId",
+        "accountId",
+        "action",
+        "orderType",
+        "quantity",
+        "price",
+      ]));
+      expect(placeOrder?.inputSchema.additionalProperties).toBe(false);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
   it.each(["secType", "expiry", "right", "suppressConfirmations"])(
     "rejects forbidden field %s instead of stripping it",
     async (field) => {

--- a/test/read-only-mode.test.ts
+++ b/test/read-only-mode.test.ts
@@ -5,6 +5,10 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerTools } from "../src/tools.js";
 import { IBClient } from "../src/ib-client.js";
 import { IBGatewayManager } from "../src/gateway-manager.js";
+import { OrderIdempotencyStore } from "../src/order-idempotency-store.js";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 vi.mock("../src/ib-client.js");
 vi.mock("../src/gateway-manager.js");
@@ -204,6 +208,114 @@ describe("cancel_order MCP entrypoint validation", () => {
     } finally {
       await client.close();
       await server.close();
+    }
+  });
+});
+
+describe("confirm_order MCP provenance", () => {
+  it("confirms only a reply persisted by this MCP and survives a server restart", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "ib-mcp-calltool-confirm-"));
+    const storePath = path.join(dir, "orders.json");
+    const ibClient = {
+      checkAuthenticationStatus: vi.fn().mockResolvedValue(true),
+      prepareOrder: vi.fn().mockResolvedValue({ accountId: "U12345", order: { conid: 265598 } }),
+      submitPreparedOrder: vi.fn().mockResolvedValue([{ id: "reply-calltool-1", message: ["warning"] }]),
+      confirmOrder: vi.fn().mockImplementation(async (replyId: string) => (
+        replyId === "reply-calltool-1"
+          ? [{ id: "reply-calltool-2", message: ["warning 2"] }]
+          : { orderId: "submitted-after-confirm", status: "Submitted" }
+      )),
+    } as unknown as IBClient;
+
+    const callWithServer = async (calls: Array<{ name: string; arguments: Record<string, unknown> }>) => {
+      const server = new McpServer({ name: "test-server", version: "1.0.0" });
+      registerTools(server, ibClient, undefined, {
+        IB_READ_ONLY_MODE: false,
+        IB_ALLOWED_ACCOUNT_ID: "U12345",
+        IB_ORDER_IDEMPOTENCY_STORE_PATH: storePath,
+      });
+      const client = new Client({ name: "test-client", version: "1.0.0" });
+      const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      try {
+        return await Promise.all(calls.map((call) => client.callTool(call)));
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    };
+
+    try {
+      await callWithServer([{
+        name: "place_order",
+        arguments: {
+          clientOrderId: "calltool-confirm-chain",
+          accountId: "U12345",
+          symbol: "AAPL",
+          action: "BUY",
+          orderType: "LMT",
+          quantity: 1,
+          price: 150,
+        },
+      }]);
+      const [unknown] = await callWithServer([
+        { name: "confirm_order", arguments: { replyId: "unknown", messageIds: [] } },
+      ]);
+      const [confirmed] = await callWithServer([
+        { name: "confirm_order", arguments: { replyId: "reply-calltool-1", messageIds: [] } },
+      ]);
+      const [secondStep] = await callWithServer([
+        { name: "confirm_order", arguments: { replyId: "reply-calltool-2", messageIds: [] } },
+      ]);
+
+      expect(JSON.stringify(unknown.content)).toMatch(/not authorized/i);
+      expect(JSON.stringify(confirmed.content)).toContain("reply-calltool-2");
+      expect(JSON.stringify(secondStep.content)).toContain("submitted-after-confirm");
+
+      const store = new OrderIdempotencyStore(storePath);
+      const baseOrder = {
+        symbol: "AAPL",
+        action: "BUY" as const,
+        orderType: "LMT" as const,
+        quantity: 1,
+        price: 150,
+      };
+      const foreign = { ...baseOrder, clientOrderId: "foreign", accountId: "U99999" };
+      await store.reserve(foreign);
+      await store.recordResponse(foreign, [{ id: "foreign-reply", message: ["warning"] }]);
+      const [foreignResult] = await callWithServer([
+        { name: "confirm_order", arguments: { replyId: "foreign-reply", messageIds: [] } },
+      ]);
+      expect(JSON.stringify(foreignResult.content)).toMatch(/not authorized/i);
+
+      for (const clientOrderId of ["duplicate-a", "duplicate-b"]) {
+        const order = { ...baseOrder, clientOrderId, accountId: "U12345" };
+        await store.reserve(order);
+        await store.recordResponse(order, [{ id: "duplicate-reply", message: ["warning"] }]);
+      }
+      const [duplicate] = await callWithServer([
+        { name: "confirm_order", arguments: { replyId: "duplicate-reply", messageIds: [] } },
+      ]);
+      expect(JSON.stringify(duplicate.content)).toMatch(/ambiguous/i);
+
+      const persistenceOrder = { ...baseOrder, clientOrderId: "persistence", accountId: "U12345" };
+      await store.reserve(persistenceOrder);
+      await store.recordResponse(persistenceOrder, [{ id: "persistence-reply", message: ["warning"] }]);
+      const persistenceSpy = vi.spyOn(OrderIdempotencyStore.prototype, "recordConfirmationResponse")
+        .mockRejectedValueOnce(new Error("injected persistence failure"));
+      const [persistenceResult] = await callWithServer([
+        { name: "confirm_order", arguments: { replyId: "persistence-reply", messageIds: [] } },
+      ]);
+      persistenceSpy.mockRestore();
+      expect(JSON.parse((persistenceResult.content[0] as { text: string }).text)).toMatchObject({
+        code: "SUBMISSION_UNCERTAIN",
+        submissionUncertain: true,
+        brokerResponse: { orderId: "submitted-after-confirm" },
+      });
+      expect(ibClient.confirmOrder).toHaveBeenCalledTimes(3);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
     }
   });
 });

--- a/test/read-only-mode.test.ts
+++ b/test/read-only-mode.test.ts
@@ -161,3 +161,49 @@ describe("place_order MCP entrypoint validation", () => {
     },
   );
 });
+
+describe("cancel_order MCP entrypoint validation", () => {
+  it("rejects unknown fields at the real callTool boundary without cancelling", async () => {
+    const server = new McpServer({ name: "test-server", version: "1.0.0" });
+    const ibClient = {
+      checkAuthenticationStatus: vi.fn().mockResolvedValue(true),
+      cancelOrder: vi.fn().mockResolvedValue({ orderId: "123", status: "Cancelled" }),
+    } as unknown as IBClient;
+    registerTools(server, ibClient, undefined, {
+      IB_READ_ONLY_MODE: false,
+      IB_ALLOWED_ACCOUNT_ID: "U12345",
+    });
+
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const { tools } = await client.listTools();
+      const cancelOrder = tools.find((tool) => tool.name === "cancel_order");
+      expect(cancelOrder?.inputSchema).toMatchObject({
+        type: "object",
+        required: expect.arrayContaining(["accountId", "orderId"]),
+        additionalProperties: false,
+      });
+      expect(Object.keys(cancelOrder?.inputSchema.properties ?? {})).toEqual(["accountId", "orderId"]);
+
+      const result = await client.callTool({
+        name: "cancel_order",
+        arguments: {
+          accountId: "U12345",
+          orderId: "123",
+          suppressConfirmations: true,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(JSON.stringify(result.content)).toMatch(/unrecognized|invalid/i);
+      expect(ibClient.cancelOrder).not.toHaveBeenCalled();
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/test/read-only-mode.test.ts
+++ b/test/read-only-mode.test.ts
@@ -219,7 +219,11 @@ describe("confirm_order MCP provenance", () => {
     const ibClient = {
       checkAuthenticationStatus: vi.fn().mockResolvedValue(true),
       prepareOrder: vi.fn().mockResolvedValue({ accountId: "U12345", order: { conid: 265598 } }),
-      submitPreparedOrder: vi.fn().mockResolvedValue([{ id: "reply-calltool-1", message: ["warning"] }]),
+      submitPreparedOrder: vi.fn().mockResolvedValue([{
+        id: "reply-calltool-1",
+        message: ["warning"],
+        messageIds: ["calltool-warning-id"],
+      }]),
       confirmOrder: vi.fn().mockImplementation(async (replyId: string) => (
         replyId === "reply-calltool-1"
           ? [{ id: "reply-calltool-2", message: ["warning 2"] }]
@@ -263,7 +267,7 @@ describe("confirm_order MCP provenance", () => {
         { name: "confirm_order", arguments: { replyId: "unknown", messageIds: [] } },
       ]);
       const [confirmed] = await callWithServer([
-        { name: "confirm_order", arguments: { replyId: "reply-calltool-1", messageIds: [] } },
+        { name: "confirm_order", arguments: { replyId: "reply-calltool-1" } },
       ]);
       const [secondStep] = await callWithServer([
         { name: "confirm_order", arguments: { replyId: "reply-calltool-2", messageIds: [] } },
@@ -271,6 +275,10 @@ describe("confirm_order MCP provenance", () => {
 
       expect(JSON.stringify(unknown.content)).toMatch(/not authorized/i);
       expect(JSON.stringify(confirmed.content)).toContain("reply-calltool-2");
+      expect(ibClient.confirmOrder).toHaveBeenCalledWith(
+        "reply-calltool-1",
+        ["calltool-warning-id"],
+      );
       expect(JSON.stringify(secondStep.content)).toContain("submitted-after-confirm");
 
       const store = new OrderIdempotencyStore(storePath);

--- a/test/tool-definitions.test.ts
+++ b/test/tool-definitions.test.ts
@@ -323,9 +323,13 @@ describe('Tool Definitions - Zod Schemas', () => {
   });
 
   describe('ConfirmOrderZodSchema', () => {
-    it('should require replyId and messageIds', () => {
+    it('should require replyId', () => {
       const result = ConfirmOrderZodSchema.safeParse({});
       expect(result.success).toBe(false);
+    });
+
+    it('allows messageIds to be omitted so persisted evidence is authoritative', () => {
+      expect(ConfirmOrderZodSchema.safeParse({ replyId: 'reply-123' }).success).toBe(true);
     });
 
     it('should accept valid confirmation data', () => {

--- a/test/tool-definitions.test.ts
+++ b/test/tool-definitions.test.ts
@@ -14,7 +14,52 @@ import {
 
 describe('Tool Definitions - Zod Schemas', () => {
   describe('PlaceOrderZodSchema', () => {
-    it('should accept valid market order', () => {
+    const validLimitOrder = {
+      clientOrderId: 'codex-20260716-001',
+      accountId: 'U12345',
+      symbol: 'AAPL',
+      action: 'BUY' as const,
+      orderType: 'LMT' as const,
+      quantity: 10,
+      price: 150.50,
+    };
+
+    it('should accept a valid limit stock order by symbol or conid', () => {
+      expect(PlaceOrderZodSchema.safeParse(validLimitOrder).success).toBe(true);
+      expect(PlaceOrderZodSchema.safeParse({
+        ...validLimitOrder,
+        symbol: undefined,
+        conid: 265598,
+      }).success).toBe(true);
+    });
+
+    it.each([
+      ['MKT', { orderType: 'MKT' }],
+      ['STP', { orderType: 'STP', stopPrice: 140 }],
+      ['option secType', { secType: 'OPT' }],
+      ['option expiry', { expiry: 'JAN27' }],
+      ['option strike', { strike: 200 }],
+      ['option right', { right: 'C' }],
+      ['suppress confirmations', { suppressConfirmations: true }],
+    ])('should reject unsafe order input %s', (_label, override) => {
+      expect(PlaceOrderZodSchema.safeParse({ ...validLimitOrder, ...override }).success).toBe(false);
+    });
+
+    it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+      'should reject invalid price %s',
+      (price) => expect(PlaceOrderZodSchema.safeParse({ ...validLimitOrder, price }).success).toBe(false),
+    );
+
+    it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+      'should reject invalid quantity %s',
+      (quantity) => expect(PlaceOrderZodSchema.safeParse({ ...validLimitOrder, quantity }).success).toBe(false),
+    );
+
+    it('should reject a blank client order ID', () => {
+      expect(PlaceOrderZodSchema.safeParse({ ...validLimitOrder, clientOrderId: '   ' }).success).toBe(false);
+    });
+
+    it('should reject a market order', () => {
       const validOrder = {
         accountId: 'U12345',
         symbol: 'AAPL',
@@ -24,10 +69,10 @@ describe('Tool Definitions - Zod Schemas', () => {
       };
       
       const result = PlaceOrderZodSchema.safeParse(validOrder);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
-    it('should accept fractional quantities as numbers', () => {
+    it('should reject a market order with fractional numeric quantity', () => {
       const validOrder = {
         accountId: 'U12345',
         symbol: 'AAPL',
@@ -37,13 +82,13 @@ describe('Tool Definitions - Zod Schemas', () => {
       };
       
       const result = PlaceOrderZodSchema.safeParse(validOrder);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       if (result.success) {
         expect(result.data.quantity).toBe(1.5);
       }
     });
 
-    it('should accept fractional quantities as strings', () => {
+    it('should reject a market order with fractional string quantity', () => {
       const validOrder = {
         accountId: 'U12345',
         symbol: 'AAPL',
@@ -53,13 +98,13 @@ describe('Tool Definitions - Zod Schemas', () => {
       };
       
       const result = PlaceOrderZodSchema.safeParse(validOrder);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       if (result.success) {
         expect(result.data.quantity).toBe(2.75);
       }
     });
 
-    it('should accept integer quantities as strings', () => {
+    it('should reject a market order with integer string quantity', () => {
       const validOrder = {
         accountId: 'U12345',
         symbol: 'AAPL',
@@ -69,7 +114,7 @@ describe('Tool Definitions - Zod Schemas', () => {
       };
       
       const result = PlaceOrderZodSchema.safeParse(validOrder);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
       if (result.success) {
         expect(result.data.quantity).toBe(100);
       }
@@ -116,6 +161,7 @@ describe('Tool Definitions - Zod Schemas', () => {
 
     it('should accept valid LMT order with price', () => {
       const validOrder = {
+        clientOrderId: 'codex-20260716-002',
         accountId: 'U12345',
         symbol: 'AAPL',
         action: 'BUY' as const,
@@ -141,7 +187,7 @@ describe('Tool Definitions - Zod Schemas', () => {
       expect(result.success).toBe(false);
     });
 
-    it('should accept valid STP order with stopPrice', () => {
+    it('should reject an STP order with stopPrice', () => {
       const validOrder = {
         accountId: 'U12345',
         symbol: 'AAPL',
@@ -152,10 +198,10 @@ describe('Tool Definitions - Zod Schemas', () => {
       };
       
       const result = PlaceOrderZodSchema.safeParse(validOrder);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
-    it('should accept suppressConfirmations flag', () => {
+    it('should reject suppressConfirmations', () => {
       const validOrder = {
         accountId: 'U12345',
         symbol: 'AAPL',
@@ -166,11 +212,11 @@ describe('Tool Definitions - Zod Schemas', () => {
       };
 
       const result = PlaceOrderZodSchema.safeParse(validOrder);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
     it.each(['DAY', 'GTC', 'IOC', 'OPG'] as const)(
-      'should accept tif value %s',
+      'should reject MKT orders even with tif value %s',
       (tif) => {
         const validOrder = {
           accountId: 'U12345',
@@ -182,7 +228,7 @@ describe('Tool Definitions - Zod Schemas', () => {
         };
 
         const result = PlaceOrderZodSchema.safeParse(validOrder);
-        expect(result.success).toBe(true);
+        expect(result.success).toBe(false);
       }
     );
 
@@ -200,7 +246,7 @@ describe('Tool Definitions - Zod Schemas', () => {
       expect(result.success).toBe(false);
     });
 
-    it('should accept exchange when provided alongside required fields', () => {
+    it('should reject MKT orders even with exchange', () => {
       const validOrder = {
         accountId: 'U12345',
         symbol: 'AAPL',
@@ -211,7 +257,7 @@ describe('Tool Definitions - Zod Schemas', () => {
       };
 
       const result = PlaceOrderZodSchema.safeParse(validOrder);
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
   });
 
@@ -425,7 +471,7 @@ describe('Tool Definitions - Zod Schemas', () => {
       }
     });
 
-    it('should accept option orders with contract details', () => {
+    it('should reject option orders with contract details', () => {
       const result = PlaceOrderZodSchema.safeParse({
         accountId: 'U12345',
         symbol: 'AAPL',
@@ -439,7 +485,7 @@ describe('Tool Definitions - Zod Schemas', () => {
         price: 4.5,
       });
 
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
     it('should reject option orders missing expiry when conid is not provided', () => {

--- a/test/tool-definitions.test.ts
+++ b/test/tool-definitions.test.ts
@@ -10,6 +10,7 @@ import {
   CreateAlertZodSchema,
   ActivateAlertZodSchema,
   DeleteAlertZodSchema,
+  CancelOrderZodSchema,
 } from '../src/tool-definitions.js';
 
 describe('Tool Definitions - Zod Schemas', () => {
@@ -341,6 +342,18 @@ describe('Tool Definitions - Zod Schemas', () => {
         messageIds: 'msg1',
       });
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe('CancelOrderZodSchema', () => {
+    it('should require non-blank accountId and orderId', () => {
+      expect(CancelOrderZodSchema.safeParse({}).success).toBe(false);
+      expect(CancelOrderZodSchema.safeParse({ accountId: ' ', orderId: '123' }).success).toBe(false);
+      expect(CancelOrderZodSchema.safeParse({ accountId: 'U12345', orderId: ' ' }).success).toBe(false);
+    });
+
+    it('should accept an account-scoped cancellation', () => {
+      expect(CancelOrderZodSchema.safeParse({ accountId: 'U12345', orderId: '123' }).success).toBe(true);
     });
   });
 

--- a/test/tool-definitions.test.ts
+++ b/test/tool-definitions.test.ts
@@ -33,6 +33,10 @@ describe('Tool Definitions - Zod Schemas', () => {
       }).success).toBe(true);
     });
 
+    it('leaves the symbol-or-conid cross-field rule to the order policy', () => {
+      expect(PlaceOrderZodSchema.safeParse({ ...validLimitOrder, symbol: undefined }).success).toBe(true);
+    });
+
     it.each([
       ['MKT', { orderType: 'MKT' }],
       ['STP', { orderType: 'STP', stopPrice: 140 }],

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -63,6 +63,8 @@ describe('ToolHandlers', () => {
         IB_GATEWAY_HOST: 'localhost',
         IB_GATEWAY_PORT: 5000,
         IB_AUTH_TIMEOUT: 10, // Use a short timeout for testing
+        IB_READ_ONLY_MODE: false,
+        IB_ALLOWED_ACCOUNT_ID: 'U12345',
       },
     };
 
@@ -138,90 +140,54 @@ describe('ToolHandlers', () => {
   });
 
   describe('placeOrder', () => {
-    it('should place market order', async () => {
+    const validOrder = {
+      clientOrderId: 'codex-20260716-001',
+      accountId: 'U12345',
+      symbol: 'AAPL',
+      action: 'BUY' as const,
+      orderType: 'LMT' as const,
+      quantity: 10,
+      price: 150.50,
+    };
+
+    it('should map an allowed limit stock order', async () => {
       const mockResponse = { orderId: '123', status: 'Submitted' };
       mockIBClient.placeOrder = vi.fn().mockResolvedValue(mockResponse);
 
-      const orderInput = {
-        accountId: 'U12345',
-        symbol: 'AAPL',
-        action: 'BUY' as const,
-        orderType: 'MKT' as const,
-        quantity: 10,
-      };
-
-      const result = await handlers.placeOrder(orderInput);
+      const result = await handlers.placeOrder(validOrder);
 
       expect(result.content).toBeDefined();
       expect(mockIBClient.placeOrder).toHaveBeenCalledWith(
         expect.objectContaining({
+          clientOrderId: 'codex-20260716-001',
           accountId: 'U12345',
           symbol: 'AAPL',
           action: 'BUY',
-          orderType: 'MKT',
+          orderType: 'LMT',
           quantity: 10,
-        })
-      );
-    });
-
-    it('should place limit order with price', async () => {
-      const mockResponse = { orderId: '123', status: 'Submitted' };
-      mockIBClient.placeOrder = vi.fn().mockResolvedValue(mockResponse);
-
-      const orderInput = {
-        accountId: 'U12345',
-        symbol: 'AAPL',
-        action: 'BUY' as const,
-        orderType: 'LMT' as const,
-        quantity: 10,
-        price: 150.50,
-      };
-
-      await handlers.placeOrder(orderInput);
-
-      expect(mockIBClient.placeOrder).toHaveBeenCalledWith(
-        expect.objectContaining({
           price: 150.50,
         })
       );
     });
 
-    it('should forward exchange and tif to ibClient.placeOrder when provided', async () => {
-      const mockResponse = { orderId: '123', status: 'Submitted' };
-      mockIBClient.placeOrder = vi.fn().mockResolvedValue(mockResponse);
+    it('should reject account mismatch before calling the IB client', async () => {
+      const result = await handlers.placeOrder({ ...validOrder, accountId: 'U99999' });
 
-      const orderInput = {
-        accountId: 'U12345',
-        symbol: 'AAPL',
-        action: 'BUY' as const,
-        orderType: 'MKT' as const,
-        quantity: 10,
-        exchange: 'NASDAQ',
-        tif: 'GTC' as const,
-      };
+      expect(result.content[0].text).toContain('U12345');
+      expect(mockIBClient.placeOrder).not.toHaveBeenCalled();
+    });
 
-      await handlers.placeOrder(orderInput);
+    it('should reject unsafe direct calls that bypass schema validation', async () => {
+      const result = await handlers.placeOrder({ ...validOrder, orderType: 'MKT' } as any);
 
-      expect(mockIBClient.placeOrder).toHaveBeenCalledWith(
-        expect.objectContaining({
-          exchange: 'NASDAQ',
-          tif: 'GTC',
-        })
-      );
+      expect(result.content[0].text).toMatch(/LMT|limit/i);
+      expect(mockIBClient.placeOrder).not.toHaveBeenCalled();
     });
 
     it('should handle order placement errors', async () => {
       mockIBClient.placeOrder = vi.fn().mockRejectedValue(new Error('Order failed'));
 
-      const orderInput = {
-        accountId: 'U12345',
-        symbol: 'AAPL',
-        action: 'BUY' as const,
-        orderType: 'MKT' as const,
-        quantity: 10,
-      };
-
-      const result = await handlers.placeOrder(orderInput);
+      const result = await handlers.placeOrder(validOrder);
 
       expect(result.content[0].text).toContain('Order failed');
     });
@@ -637,10 +603,11 @@ describe('ToolHandlers', () => {
       expect(result.content[0].text).toContain('"conid": 912345678');
     });
 
-    it('should pass option order fields through to the IB client', async () => {
+    it('should reject option order fields before calling the IB client', async () => {
       mockIBClient.placeOrder = vi.fn().mockResolvedValue({ orderId: '123', status: 'Submitted' });
 
-      await handlers.placeOrder({
+      const result = await handlers.placeOrder({
+        clientOrderId: 'codex-20260716-option',
         accountId: 'U12345',
         symbol: 'AAPL',
         secType: 'OPT',
@@ -651,18 +618,10 @@ describe('ToolHandlers', () => {
         orderType: 'LMT',
         quantity: 1,
         price: 4.5,
-      });
+      } as any);
 
-      expect(mockIBClient.placeOrder).toHaveBeenCalledWith(
-        expect.objectContaining({
-          symbol: 'AAPL',
-          secType: 'OPT',
-          expiry: 'JAN27',
-          strike: 200,
-          right: 'C',
-          price: 4.5,
-        }),
-      );
+      expect(result.content[0].text).toMatch(/option|secType|unsupported/i);
+      expect(mockIBClient.placeOrder).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -393,7 +393,7 @@ describe('ToolHandlers', () => {
     }
 
     it('confirms an allowlisted persisted reply after restart and persists the next reply', async () => {
-      await persistWarning([{ id: 'reply-123', message: ['warning'] }]);
+      await persistWarning([{ id: 'reply-123', message: ['warning'], messageIds: ['msg1', 'msg2'] }]);
       const mockResponse = [{ id: 'reply-456', message: ['next warning'] }];
       mockIBClient.confirmOrder = vi.fn().mockResolvedValue(mockResponse);
       const restarted = new ToolHandlers({
@@ -412,6 +412,57 @@ describe('ToolHandlers', () => {
         .toMatchObject([{ replyId: 'reply-123', state: 'completed', response: mockResponse }]);
     });
 
+    it('accepts reordered-equivalent messageIds but sends the persisted order', async () => {
+      await persistWarning([{ id: 'reply-reordered', message: ['warning'], messageIds: ['o2', 'o1'] }]);
+
+      await handlers.confirmOrder({ replyId: 'reply-reordered', messageIds: ['o1', 'o2'] });
+
+      expect(mockIBClient.confirmOrder).toHaveBeenCalledWith('reply-reordered', ['o2', 'o1']);
+    });
+
+    it('fails closed when caller messageIds do not equal persisted warning evidence', async () => {
+      await persistWarning([{ id: 'reply-mismatch', message: ['warning'], messageIds: ['o1', 'o2'] }]);
+
+      const result = await handlers.confirmOrder({ replyId: 'reply-mismatch', messageIds: ['o1', 'other'] });
+
+      expect(result.content[0].text).toMatch(/messageIds.*persisted|mismatch/i);
+      expect(mockIBClient.confirmOrder).not.toHaveBeenCalled();
+    });
+
+    it('durably preserves structured confirmation HTTP evidence and does not replay the POST', async () => {
+      await persistWarning([{ id: 'reply-http-error', message: ['warning'], messageIds: ['o1'] }]);
+      const { OrderConfirmationError } = await vi.importActual<typeof import('../src/ib-client.js')>('../src/ib-client.js');
+      mockIBClient.confirmOrder = vi.fn().mockRejectedValue(new OrderConfirmationError({
+        message: 'confirmation failed after HTTP 503',
+        status: 503,
+        ibkrBody: { error: 'gateway timeout', detail: { broker: 'raw' } },
+        transportCode: 'UND_ERR_HEADERS_TIMEOUT',
+        submissionUncertain: true,
+      }));
+
+      const first = await handlers.confirmOrder({ replyId: 'reply-http-error', messageIds: ['o1'] });
+      const restarted = new ToolHandlers({
+        ...context,
+        orderIdempotencyStore: new OrderIdempotencyStore(path.join(orderStoreDir, 'orders.json')),
+      });
+      const replay = await restarted.confirmOrder({ replyId: 'reply-http-error', messageIds: ['o1'] });
+
+      expect(JSON.parse(first.content[0].text)).toMatchObject({
+        code: 'SUBMISSION_UNCERTAIN',
+        status: 503,
+        brokerResponse: { error: 'gateway timeout', detail: { broker: 'raw' } },
+        transportCode: 'UND_ERR_HEADERS_TIMEOUT',
+      });
+      expect(JSON.parse(replay.content[0].text)).toMatchObject({
+        code: 'SUBMISSION_UNCERTAIN',
+        confirmationAttempt: {
+          state: 'uncertain',
+          error: { brokerResponse: { error: 'gateway timeout' } },
+        },
+      });
+      expect(mockIBClient.confirmOrder).toHaveBeenCalledTimes(1);
+    });
+
     it('supports multiple confirmation steps across restarts', async () => {
       await persistWarning([{ id: 'reply-1', message: ['warning'] }]);
       mockIBClient.confirmOrder = vi.fn()
@@ -422,7 +473,7 @@ describe('ToolHandlers', () => {
       const second = await new ToolHandlers({
         ...context,
         orderIdempotencyStore: new OrderIdempotencyStore(path.join(orderStoreDir, 'orders.json')),
-      }).confirmOrder({ replyId: 'reply-2', messageIds: [] });
+      }).confirmOrder({ replyId: 'reply-2', messageIds: ['o123'] });
 
       expect(JSON.parse(second.content[0].text)).toMatchObject({ orderId: 'broker-order-1' });
       expect(mockIBClient.confirmOrder).toHaveBeenCalledTimes(2);

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -280,12 +280,63 @@ describe('ToolHandlers', () => {
       expect(JSON.parse(first.content[0].text)).toMatchObject({
         code: 'SUBMISSION_UNCERTAIN',
         submissionUncertain: true,
+        brokerResponse: { orderId: 'accepted-before-crash' },
+        persistenceError: { message: 'disk failed after POST' },
       });
       expect(JSON.parse(replay.content[0].text)).toMatchObject({
         code: 'SUBMISSION_UNCERTAIN',
         submissionUncertain: true,
+        persistedRecord: {
+          error: { brokerResponse: { orderId: 'accepted-before-crash' } },
+        },
       });
       expect(mockIBClient.submitPreparedOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns exact broker response when both terminal and fallback persistence fail', async () => {
+      mockIBClient.submitPreparedOrder = vi.fn().mockResolvedValue({ orderId: 'accepted-before-double-failure' });
+      const store = context.orderIdempotencyStore!;
+      store.recordResponse = vi.fn().mockRejectedValue(new Error('terminal persistence failed'));
+      store.recordUncertain = vi.fn().mockRejectedValue(new Error('fallback persistence failed'));
+
+      const first = await handlers.placeOrder(validOrder);
+      const replay = await new ToolHandlers(context).placeOrder(validOrder);
+
+      expect(JSON.parse(first.content[0].text)).toMatchObject({
+        code: 'SUBMISSION_UNCERTAIN',
+        submissionUncertain: true,
+        brokerResponse: { orderId: 'accepted-before-double-failure' },
+        persistenceError: { message: 'terminal persistence failed' },
+      });
+      expect(JSON.parse(replay.content[0].text)).toMatchObject({
+        code: 'SUBMISSION_UNCERTAIN',
+        persistedRecord: { state: 'reserved' },
+      });
+      expect(mockIBClient.submitPreparedOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      { submissionUncertain: true, persistenceMethod: 'recordUncertain' as const },
+      { submissionUncertain: false, persistenceMethod: 'recordResponse' as const },
+    ])('does not replace a structured submission response when $persistenceMethod fails', async ({ submissionUncertain, persistenceMethod }) => {
+      const structured = Object.assign(new Error('structured broker outcome'), {
+        name: 'OrderSubmissionError',
+        status: 400,
+        ibkrBody: { errorCode: 201, error: 'Order rejected' },
+        submissionUncertain,
+      });
+      mockIBClient.submitPreparedOrder = vi.fn().mockRejectedValue(structured);
+      context.orderIdempotencyStore![persistenceMethod] = vi.fn().mockRejectedValue(new Error('persistence unavailable'));
+
+      const result = await handlers.placeOrder(validOrder);
+
+      expect(JSON.parse(result.content[0].text)).toMatchObject({
+        code: submissionUncertain ? 'SUBMISSION_UNCERTAIN' : 'ORDER_SUBMISSION_FAILED',
+        message: 'structured broker outcome',
+        status: 400,
+        ibkrBody: { errorCode: 201, error: 'Order rejected' },
+        submissionUncertain,
+      });
     });
   });
 

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -4,6 +4,10 @@ import { ToolHandlers, ToolHandlerContext } from '../src/tool-handlers.js';
 import { IBClient } from '../src/ib-client.js';
 import { IBGatewayManager } from '../src/gateway-manager.js';
 import { HeadlessAuthenticator } from '../src/headless-auth.js';
+import { OrderIdempotencyStore } from '../src/order-idempotency-store.js';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import open from 'open';
 
 // Mock dependencies
@@ -17,9 +21,11 @@ describe('ToolHandlers', () => {
   let mockIBClient: IBClient;
   let mockGatewayManager: IBGatewayManager;
   let context: ToolHandlerContext;
+  let orderStoreDir: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    orderStoreDir = await mkdtemp(path.join(tmpdir(), 'ib-mcp-handler-orders-'));
   vi.mocked(HeadlessAuthenticator).mockImplementation(function MockHeadlessAuthenticator() {
     return {
       authenticate: vi.fn().mockResolvedValue({ success: true }),
@@ -66,13 +72,15 @@ describe('ToolHandlers', () => {
         IB_READ_ONLY_MODE: false,
         IB_ALLOWED_ACCOUNT_ID: 'U12345',
       },
+      orderIdempotencyStore: new OrderIdempotencyStore(path.join(orderStoreDir, 'orders.json')),
     };
 
     handlers = new ToolHandlers(context);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
+    await rm(orderStoreDir, { recursive: true, force: true });
   });
 
 
@@ -190,6 +198,47 @@ describe('ToolHandlers', () => {
       const result = await handlers.placeOrder(validOrder);
 
       expect(result.content[0].text).toContain('Order failed');
+    });
+
+    it('should replay a completed result after handler restart without submitting again', async () => {
+      const response = [{ id: 'order-123', status: 'Submitted' }];
+      mockIBClient.placeOrder = vi.fn().mockResolvedValue(response);
+      const first = await handlers.placeOrder(validOrder);
+
+      const restarted = new ToolHandlers({
+        ...context,
+        orderIdempotencyStore: new OrderIdempotencyStore(path.join(orderStoreDir, 'orders.json')),
+      });
+      const replay = await restarted.placeOrder({ ...validOrder });
+
+      expect(JSON.parse(first.content[0].text)).toEqual(response);
+      expect(JSON.parse(replay.content[0].text)).toEqual(response);
+      expect(mockIBClient.placeOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it('should persist transport timeouts as SUBMISSION_UNCERTAIN and never auto-retry', async () => {
+      const transportError = Object.assign(new Error('request timed out'), {
+        name: 'OrderSubmissionError',
+        transportCode: 'UND_ERR_CONNECT_TIMEOUT',
+        submissionUncertain: true,
+      });
+      mockIBClient.placeOrder = vi.fn().mockRejectedValue(transportError);
+
+      const first = await handlers.placeOrder(validOrder);
+      const second = await handlers.placeOrder({ ...validOrder });
+      const firstPayload = JSON.parse(first.content[0].text);
+      const secondPayload = JSON.parse(second.content[0].text);
+
+      expect(firstPayload).toMatchObject({
+        code: 'SUBMISSION_UNCERTAIN',
+        submissionUncertain: true,
+        transportCode: 'UND_ERR_CONNECT_TIMEOUT',
+      });
+      expect(secondPayload).toMatchObject({
+        state: 'uncertain',
+        error: { submissionUncertain: true },
+      });
+      expect(mockIBClient.placeOrder).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -376,17 +376,97 @@ describe('ToolHandlers', () => {
   });
 
   describe('confirmOrder', () => {
-    it('should confirm order', async () => {
-      const mockResponse = { confirmed: true };
-      mockIBClient.confirmOrder = vi.fn().mockResolvedValue(mockResponse);
+    const warningOrder = {
+      clientOrderId: 'codex-confirm-chain',
+      accountId: 'U12345',
+      symbol: 'AAPL',
+      action: 'BUY' as const,
+      orderType: 'LMT' as const,
+      quantity: 1,
+      price: 150,
+    };
 
-      const result = await handlers.confirmOrder({
+    async function persistWarning(response: unknown, order = warningOrder) {
+      const store = context.orderIdempotencyStore!;
+      await store.reserve(order);
+      await store.recordResponse(order, response);
+    }
+
+    it('confirms an allowlisted persisted reply after restart and persists the next reply', async () => {
+      await persistWarning([{ id: 'reply-123', message: ['warning'] }]);
+      const mockResponse = [{ id: 'reply-456', message: ['next warning'] }];
+      mockIBClient.confirmOrder = vi.fn().mockResolvedValue(mockResponse);
+      const restarted = new ToolHandlers({
+        ...context,
+        orderIdempotencyStore: new OrderIdempotencyStore(path.join(orderStoreDir, 'orders.json')),
+      });
+
+      const result = await restarted.confirmOrder({
         replyId: 'reply-123',
         messageIds: ['msg1', 'msg2'],
       });
 
-      expect(result.content).toBeDefined();
+      expect(JSON.parse(result.content[0].text)).toEqual(mockResponse);
       expect(mockIBClient.confirmOrder).toHaveBeenCalledWith('reply-123', ['msg1', 'msg2']);
+      expect((await context.orderIdempotencyStore!.get(warningOrder.clientOrderId))?.confirmations)
+        .toMatchObject([{ replyId: 'reply-123', state: 'completed', response: mockResponse }]);
+    });
+
+    it('supports multiple confirmation steps across restarts', async () => {
+      await persistWarning([{ id: 'reply-1', message: ['warning'] }]);
+      mockIBClient.confirmOrder = vi.fn()
+        .mockResolvedValueOnce([{ id: 'reply-2', messageIds: ['o123'] }])
+        .mockResolvedValueOnce({ orderId: 'broker-order-1', status: 'Submitted' });
+
+      await new ToolHandlers({ ...context }).confirmOrder({ replyId: 'reply-1', messageIds: [] });
+      const second = await new ToolHandlers({
+        ...context,
+        orderIdempotencyStore: new OrderIdempotencyStore(path.join(orderStoreDir, 'orders.json')),
+      }).confirmOrder({ replyId: 'reply-2', messageIds: [] });
+
+      expect(JSON.parse(second.content[0].text)).toMatchObject({ orderId: 'broker-order-1' });
+      expect(mockIBClient.confirmOrder).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      ['unknown', [{ id: 'known', message: ['warning'] }]],
+      ['duplicate', [{ id: 'duplicate', message: ['warning'] }, { id: 'duplicate', messageIds: ['o123'] }]],
+    ])('fails closed for %s reply provenance', async (replyId, brokerResponse) => {
+      await persistWarning(brokerResponse);
+
+      const result = await handlers.confirmOrder({ replyId, messageIds: [] });
+
+      expect(result.content[0].text).toMatch(/not authorized|ambiguous/i);
+      expect(mockIBClient.confirmOrder).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when the persisted record belongs to another account', async () => {
+      await persistWarning([{ id: 'reply-foreign', message: ['warning'] }], { ...warningOrder, accountId: 'U99999' });
+
+      const result = await handlers.confirmOrder({ replyId: 'reply-foreign', messageIds: [] });
+
+      expect(result.content[0].text).toMatch(/not authorized/i);
+      expect(mockIBClient.confirmOrder).not.toHaveBeenCalled();
+    });
+
+    it('returns SUBMISSION_UNCERTAIN and preserves brokerResponse when terminal persistence fails', async () => {
+      await persistWarning([{ id: 'reply-persist-fail', message: ['warning'] }]);
+      const brokerResponse = [{ id: 'reply-next-sensitive', message: ['warning'] }];
+      mockIBClient.confirmOrder = vi.fn().mockResolvedValue(brokerResponse);
+      const store = context.orderIdempotencyStore!;
+      vi.spyOn(store, 'recordConfirmationResponse').mockRejectedValueOnce(new Error('disk unavailable'));
+
+      const result = await handlers.confirmOrder({ replyId: 'reply-persist-fail', messageIds: [] });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed).toMatchObject({
+        code: 'SUBMISSION_UNCERTAIN',
+        submissionUncertain: true,
+        brokerResponse,
+      });
+      const replay = await handlers.confirmOrder({ replyId: 'reply-persist-fail', messageIds: [] });
+      expect(replay.content[0].text).toMatch(/already attempted|uncertain/i);
+      expect(mockIBClient.confirmOrder).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -41,6 +41,8 @@ describe('ToolHandlers', () => {
       getPositions: vi.fn().mockResolvedValue([]),
       getMarketData: vi.fn().mockResolvedValue({ price: 150 }),
       placeOrder: vi.fn().mockResolvedValue({ orderId: '123' }),
+      prepareOrder: vi.fn().mockImplementation(async (order) => ({ accountId: order.accountId, order: { conid: order.conid ?? 265598 } })),
+      submitPreparedOrder: vi.fn().mockResolvedValue({ orderId: '123' }),
       getOrderStatus: vi.fn().mockResolvedValue({ status: 'Filled' }),
       getOrders: vi.fn().mockResolvedValue([]),
       confirmOrder: vi.fn().mockResolvedValue({ confirmed: true }),
@@ -160,12 +162,12 @@ describe('ToolHandlers', () => {
 
     it('should map an allowed limit stock order', async () => {
       const mockResponse = { orderId: '123', status: 'Submitted' };
-      mockIBClient.placeOrder = vi.fn().mockResolvedValue(mockResponse);
+      mockIBClient.submitPreparedOrder = vi.fn().mockResolvedValue(mockResponse);
 
       const result = await handlers.placeOrder(validOrder);
 
       expect(result.content).toBeDefined();
-      expect(mockIBClient.placeOrder).toHaveBeenCalledWith(
+      expect(mockIBClient.prepareOrder).toHaveBeenCalledWith(
         expect.objectContaining({
           clientOrderId: 'codex-20260716-001',
           accountId: 'U12345',
@@ -176,6 +178,7 @@ describe('ToolHandlers', () => {
           price: 150.50,
         })
       );
+      expect(mockIBClient.submitPreparedOrder).toHaveBeenCalledTimes(1);
     });
 
     it('should reject account mismatch before calling the IB client', async () => {
@@ -193,7 +196,7 @@ describe('ToolHandlers', () => {
     });
 
     it('should handle order placement errors', async () => {
-      mockIBClient.placeOrder = vi.fn().mockRejectedValue(new Error('Order failed'));
+      mockIBClient.submitPreparedOrder = vi.fn().mockRejectedValue(new Error('Order failed'));
 
       const result = await handlers.placeOrder(validOrder);
 
@@ -202,7 +205,7 @@ describe('ToolHandlers', () => {
 
     it('should replay a completed result after handler restart without submitting again', async () => {
       const response = [{ id: 'order-123', status: 'Submitted' }];
-      mockIBClient.placeOrder = vi.fn().mockResolvedValue(response);
+      mockIBClient.submitPreparedOrder = vi.fn().mockResolvedValue(response);
       const first = await handlers.placeOrder(validOrder);
 
       const restarted = new ToolHandlers({
@@ -213,7 +216,7 @@ describe('ToolHandlers', () => {
 
       expect(JSON.parse(first.content[0].text)).toEqual(response);
       expect(JSON.parse(replay.content[0].text)).toEqual(response);
-      expect(mockIBClient.placeOrder).toHaveBeenCalledTimes(1);
+      expect(mockIBClient.submitPreparedOrder).toHaveBeenCalledTimes(1);
     });
 
     it('should persist transport timeouts as SUBMISSION_UNCERTAIN and never auto-retry', async () => {
@@ -222,7 +225,7 @@ describe('ToolHandlers', () => {
         transportCode: 'UND_ERR_CONNECT_TIMEOUT',
         submissionUncertain: true,
       });
-      mockIBClient.placeOrder = vi.fn().mockRejectedValue(transportError);
+      mockIBClient.submitPreparedOrder = vi.fn().mockRejectedValue(transportError);
 
       const first = await handlers.placeOrder(validOrder);
       const second = await handlers.placeOrder({ ...validOrder });
@@ -235,10 +238,54 @@ describe('ToolHandlers', () => {
         transportCode: 'UND_ERR_CONNECT_TIMEOUT',
       });
       expect(secondPayload).toMatchObject({
-        state: 'uncertain',
-        error: { submissionUncertain: true },
+        code: 'SUBMISSION_UNCERTAIN',
+        submissionUncertain: true,
+        persistedRecord: { state: 'uncertain', error: { submissionUncertain: true } },
       });
-      expect(mockIBClient.placeOrder).toHaveBeenCalledTimes(1);
+      expect(mockIBClient.submitPreparedOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reserve the client order ID when contract preflight fails', async () => {
+      mockIBClient.prepareOrder = vi.fn().mockRejectedValue(new Error('contract preflight failed'));
+
+      const result = await handlers.placeOrder(validOrder);
+
+      expect(result.content[0].text).toContain('contract preflight failed');
+      expect(await context.orderIdempotencyStore!.get(validOrder.clientOrderId)).toBeUndefined();
+      expect(mockIBClient.submitPreparedOrder).not.toHaveBeenCalled();
+    });
+
+    it('replays a persisted reserved record as explicit SUBMISSION_UNCERTAIN after restart', async () => {
+      await context.orderIdempotencyStore!.reserve(validOrder);
+      const restarted = new ToolHandlers(context);
+
+      const result = await restarted.placeOrder(validOrder);
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(payload).toMatchObject({ code: 'SUBMISSION_UNCERTAIN', submissionUncertain: true });
+      expect(payload.message).toMatch(/manual|manually|人工|IBKR/i);
+      expect(mockIBClient.prepareOrder).not.toHaveBeenCalled();
+      expect(mockIBClient.submitPreparedOrder).not.toHaveBeenCalled();
+    });
+
+    it('reports SUBMISSION_UNCERTAIN when the POST succeeds but terminal persistence fails', async () => {
+      mockIBClient.prepareOrder = vi.fn().mockResolvedValue({ accountId: validOrder.accountId, order: { conid: 265598 } });
+      mockIBClient.submitPreparedOrder = vi.fn().mockResolvedValue({ orderId: 'accepted-before-crash' });
+      const store = context.orderIdempotencyStore!;
+      store.recordResponse = vi.fn().mockRejectedValue(new Error('disk failed after POST'));
+
+      const first = await handlers.placeOrder(validOrder);
+      const replay = await new ToolHandlers(context).placeOrder(validOrder);
+
+      expect(JSON.parse(first.content[0].text)).toMatchObject({
+        code: 'SUBMISSION_UNCERTAIN',
+        submissionUncertain: true,
+      });
+      expect(JSON.parse(replay.content[0].text)).toMatchObject({
+        code: 'SUBMISSION_UNCERTAIN',
+        submissionUncertain: true,
+      });
+      expect(mockIBClient.submitPreparedOrder).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/test/tool-handlers.test.ts
+++ b/test/tool-handlers.test.ts
@@ -46,6 +46,7 @@ describe('ToolHandlers', () => {
       getOrderStatus: vi.fn().mockResolvedValue({ status: 'Filled' }),
       getOrders: vi.fn().mockResolvedValue([]),
       confirmOrder: vi.fn().mockResolvedValue({ confirmed: true }),
+      cancelOrder: vi.fn().mockResolvedValue({ orderId: '123', status: 'Cancelled' }),
       destroy: vi.fn(),
       updatePort: vi.fn(),
       getAlerts: vi.fn().mockResolvedValue([]),
@@ -386,6 +387,53 @@ describe('ToolHandlers', () => {
 
       expect(result.content).toBeDefined();
       expect(mockIBClient.confirmOrder).toHaveBeenCalledWith('reply-123', ['msg1', 'msg2']);
+    });
+  });
+
+  describe('cancelOrder', () => {
+    it('should enforce the allowed account and preserve the broker response', async () => {
+      const brokerResponse = { orderId: '123', status: 'Cancelled', detail: { remaining: 0 } };
+      mockIBClient.cancelOrder = vi.fn().mockResolvedValue(brokerResponse);
+
+      const result = await handlers.cancelOrder({ accountId: 'U12345', orderId: '123' });
+
+      expect(mockIBClient.cancelOrder).toHaveBeenCalledWith('U12345', '123');
+      expect(JSON.parse(result.content[0].text)).toEqual(brokerResponse);
+    });
+
+    it('should reject an account mismatch before authentication or cancellation', async () => {
+      const result = await handlers.cancelOrder({ accountId: 'U99999', orderId: '123' });
+
+      expect(result.content[0].text).toContain('U12345');
+      expect(mockIBClient.checkAuthenticationStatus).not.toHaveBeenCalled();
+      expect(mockIBClient.cancelOrder).not.toHaveBeenCalled();
+    });
+
+    it('should return structured broker rejection status and body', async () => {
+      mockIBClient.cancelOrder = vi.fn().mockRejectedValue(Object.assign(new Error('Cancellation rejected'), {
+        name: 'OrderCancellationError',
+        status: 400,
+        ibkrBody: { error: 'Order cannot be cancelled', errorCode: 10147 },
+      }));
+
+      const result = await handlers.cancelOrder({ accountId: 'U12345', orderId: '123' });
+
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        code: 'ORDER_CANCELLATION_FAILED',
+        message: 'Cancellation rejected',
+        status: 400,
+        ibkrBody: { error: 'Order cannot be cancelled', errorCode: 10147 },
+      });
+    });
+
+    it('should surface authentication failures through the normal authentication guidance', async () => {
+      mockIBClient.cancelOrder = vi.fn().mockRejectedValue(Object.assign(new Error('not authenticated'), {
+        response: { status: 401, data: { error: 'not authenticated' } },
+      }));
+
+      const result = await handlers.cancelOrder({ accountId: 'U12345', orderId: '123' });
+
+      expect(result.content[0].text).toMatch(/Authentication required/);
     });
   });
 


### PR DESCRIPTION
## Summary

- make read-only mode the default and require an explicit single-account allowlist before live-write tools are registered
- restrict submissions to strict, authoritative STK/LMT orders with durable cross-process client-order idempotency
- conservatively preserve uncertain broker outcomes without automatic resubmission, while redacting mutation bodies and credentials from ordinary logs
- bind multi-step order confirmation to persisted allowlisted warning provenance
- add account-scoped `cancel_order` with strict MCP runtime validation

## Why

The existing write path could be enabled without an account boundary and did not durably prevent duplicate submission after process or transport failures. Confirmation reply IDs were also not tied to an allowlisted originating order. These changes make live writes fail closed and keep enough broker evidence for manual reconciliation.

## Safety behavior

- `IB_READ_ONLY_MODE` defaults to `true`
- write mode requires `IB_READ_ONLY_MODE=false` and `IB_ALLOWED_ACCOUNT_ID`
- only USD stock limit orders are accepted; market, stop, option, ambiguous-symbol, and auto-warning-confirmation inputs are rejected
- every order requires a unique `clientOrderId`
- every HTTP/transport submission or confirmation failure is treated as uncertain and is never automatically retried
- confirmation is authorized only from durable warning evidence for the allowlisted account
- order, confirmation, cancellation, credential, TOTP, token, cookie, and reply-capability data are redacted from ordinary logs

## Validation

- `npm test -- --run`
- `npm run lint` (existing warnings only)
- `npm run build`
- `npm audit --omit=dev` — 0 vulnerabilities
- `git diff --check 234897a..308211d`
- independent final review — 0 Critical, 0 Important, 0 Minor

The full development-dependency audit still reports 3 existing high-severity transitive findings (`lodash-es`, `picomatch`, and npm-bundled `undici`). This PR deliberately does not broaden into dependency upgrades.

No live IBKR order, confirmation, or cancellation was sent during validation.
